### PR TITLE
Change the way to verify business_day in time_slots

### DIFF
--- a/app/controllers/time_slot_controller.rb
+++ b/app/controllers/time_slot_controller.rb
@@ -1,4 +1,10 @@
+require_relative './../helpers/time_slot_helper'
+include TimeSlotHelper
+
 class TimeSlotController < PatientSessionController
+  
+  SLOTS_WINDOW_IN_DAYS = 4
+
   def schedule
     @ubs = Ubs.find(schedule_params[:ubs_id])
     start_time = Time.parse(schedule_params[:start_time])
@@ -39,9 +45,11 @@ class TimeSlotController < PatientSessionController
     # FIXME We need to change this relation to has_one or enhance the logic here
     @appointment = current_patient.appointments.last
     @ubs = @appointment.try(:ubs)
+    
+    date_range = build_weekdays_date_range(TimeSlotController::SLOTS_WINDOW_IN_DAYS)
 
     @time_slots = Ubs.all.where(active: true).each_with_object({}) do |ubs, memo|
-      memo[ubs] = ubs.available_time_slots(4)
+      memo[ubs] = ubs.available_time_slots(date_range, Time.zone.now)
     end
   end
 

--- a/app/controllers/time_slot_controller.rb
+++ b/app/controllers/time_slot_controller.rb
@@ -41,10 +41,7 @@ class TimeSlotController < PatientSessionController
     @ubs = @appointment.try(:ubs)
 
     @time_slots = Ubs.all.where(active: true).each_with_object({}) do |ubs, memo|
-      memo[ubs] = ubs.available_time_slots(Time.zone.today...3.days.from_now, Time.zone.now)
-
-      # TODO: Refactor to not include these as available
-      memo.delete(ubs) if memo[ubs].empty?
+      memo[ubs] = ubs.available_time_slots(4)
     end
   end
 

--- a/app/helpers/time_slot_helper.rb
+++ b/app/helpers/time_slot_helper.rb
@@ -6,4 +6,22 @@ module TimeSlotHelper
 
     OFFICIAL_HOLIDAYS.exclude?(formated_day) && day.on_weekday?
   end
+
+  private
+
+  def build_weekdays_date_range(available_days)
+    day_range = []
+    d = 0
+    i = 0
+    until d == available_days
+      day = i.days.from_now
+      if business_day?(day)
+        day_range << day
+        d += 1
+      end
+      i += 1
+    end
+    day_range
+  end
+
 end

--- a/app/models/concerns/time_slot.rb
+++ b/app/models/concerns/time_slot.rb
@@ -3,6 +3,10 @@ module TimeSlot
     slots_for_day = day_range.each_with_object({}) do |day, slots|
       slots[day] = available_time_slots_for_day(day, time_now)
     end
+
+    slots_for_day.reject do |_day, slots|
+      slots.empty?
+    end
   end
 
   private

--- a/app/models/concerns/time_slot.rb
+++ b/app/models/concerns/time_slot.rb
@@ -1,37 +1,20 @@
-require_relative './../../helpers/time_slot_helper'
-include TimeSlotHelper
-
 module TimeSlot
-  def available_time_slots(forward_days)
-
-    day_range = []
-    d = 0
-    i = 0
-    until d == forward_days
-      day = i.days.from_now
-      if business_day?(day)
-        day_range << day
-        puts day
-        d += 1
-      end
-      i += 1
-    end
-
+  def available_time_slots(day_range, time_now)
     slots_for_day = day_range.each_with_object({}) do |day, slots|
-      slots[day] = available_time_slots_for_day(day)
+      slots[day] = available_time_slots_for_day(day, time_now)
     end
   end
 
   private
 
-  def available_time_slots_for_day(day)
+  def available_time_slots_for_day(day, time_now)
     appointments = Appointment.where(ubs: self).active_from_day(day)
 
     all_time_slots = time_slots(morning_shift(day)) + time_slots(afternoon_shift(day))
 
     if day.today?
       all_time_slots.reject! do |slot|
-        slot[:slot_start].to_i < Time.zone.now.to_i
+        slot[:slot_start].to_i < time_now.to_i
       end
     end
 

--- a/app/models/concerns/time_slot.rb
+++ b/app/models/concerns/time_slot.rb
@@ -1,11 +1,16 @@
+require_relative './../../helpers/time_slot_helper'
+include TimeSlotHelper
+
 module TimeSlot
   def available_time_slots(day_range, current_time)
     slots_for_day = day_range.each_with_object({}) do |day, slots|
-      slots[day] = available_time_slots_for_day(day)
+      if business_day?(day)
+        slots[day] = available_time_slots_for_day(day)
 
-      if day.today?
-        slots[day].reject! do |slot|
-          slot[:slot_start].to_i < current_time.to_i
+        if day.today?
+          slots[day].reject! do |slot|
+            slot[:slot_start].to_i < current_time.to_i
+          end
         end
       end
     end

--- a/app/views/time_slot/index.html.erb
+++ b/app/views/time_slot/index.html.erb
@@ -85,35 +85,33 @@
                 <div id=<%= "ubsControl#{ubs.id}" %> class="collapse" aria-labelledby=<%= "ubsId#{ubs.id}" %> data-parent=<%= "#ubsId#{ubs.id}Accordion" %>>
                   <div class="card-body">
                     <% days.each do |day, slots| %>
-                      <% if business_day?(day) %>
-                        <div id=<%= "day#{ubs.id}Id#{day.to_s}Accordion" %>>
-                          <div class="card">
-                            <div class="card-header" id=<%= "day#{ubs.id}Id#{day.to_s}" %>>
-                              <button class="btn btn-link" data-toggle="collapse" data-target=<%= "#day#{ubs.id}Control#{day.to_s}" %> aria-expanded="true" aria-controls=<%= "day#{ubs.id}Control#{day.to_s}" %>>
-                                <%= ApplicationHelper.humanize_date(day) %>
-                              </button>
-                            </div>
-                            <div id=<%= "day#{ubs.id}Control#{day.to_s}" %> class="collapse" aria-labelledby=<%= "day#{ubs.id}Id#{day.to_s}" %> data-parent=<%= "#day#{ubs.id}Id#{day.to_s}Accordion" %>>
-                              <div class="card-body">
-                                <div class="container">
-                                  <% slots.each do |slot| %>
-                                    <div class="row">
-                                      <div class="col align-middle">
-                                        Horário <br /> <%= ApplicationHelper.humanize_time(slot[:slot_start]) %>
-                                        - <%= ApplicationHelper.humanize_time(slot[:slot_end]) %>
-                                      </div>
-                                      <div class="col text-right">
-                                        <%= button_to @appointment.present? ? 'Substituir' : 'Agendar', schedule_time_slot_path(start_time: slot[:slot_start], ubs_id: ubs.id), class: "btn btn-success" %>
-                                      </div>
+                      <div id=<%= "day#{ubs.id}Id#{day.to_s}Accordion" %>>
+                        <div class="card">
+                          <div class="card-header" id=<%= "day#{ubs.id}Id#{day.to_s}" %>>
+                            <button class="btn btn-link" data-toggle="collapse" data-target=<%= "#day#{ubs.id}Control#{day.to_s}" %> aria-expanded="true" aria-controls=<%= "day#{ubs.id}Control#{day.to_s}" %>>
+                              <%= ApplicationHelper.humanize_date(day) %>
+                            </button>
+                          </div>
+                          <div id=<%= "day#{ubs.id}Control#{day.to_s}" %> class="collapse" aria-labelledby=<%= "day#{ubs.id}Id#{day.to_s}" %> data-parent=<%= "#day#{ubs.id}Id#{day.to_s}Accordion" %>>
+                            <div class="card-body">
+                              <div class="container">
+                                <% slots.each do |slot| %>
+                                  <div class="row">
+                                    <div class="col align-middle">
+                                      Horário <br /> <%= ApplicationHelper.humanize_time(slot[:slot_start]) %>
+                                      - <%= ApplicationHelper.humanize_time(slot[:slot_end]) %>
                                     </div>
-                                    <hr/>
-                                  <% end %>
-                                </div>
+                                    <div class="col text-right">
+                                      <%= button_to @appointment.present? ? 'Substituir' : 'Agendar', schedule_time_slot_path(start_time: slot[:slot_start], ubs_id: ubs.id), class: "btn btn-success" %>
+                                    </div>
+                                  </div>
+                                  <hr/>
+                                <% end %>
                               </div>
                             </div>
                           </div>
                         </div>
-                      <% end%>
+                      </div>
                     <% end %>
                   </div>
                 </div>


### PR DESCRIPTION
Hi team,

In this PR we proposed the another way to control the business days for generating the time slots, from View to the Concerns of `TimeSlot` Model.

This change has mainly objective to avoid appears the UBS button in the `time_slot` index page if don't have any available time slot in business days.