### PR TITLE
Remove engines padrões

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -4,7 +4,6 @@ require_relative 'boot'
 
 require 'rails'
 
-
 # action_cable/engine
 # action_mailbox/engine
 # action_text/engine

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,27 @@
+# frozen_string_literal: true
+
 require_relative 'boot'
 
-require 'rails/all'
+require 'rails'
+
+
+# action_cable/engine
+# action_mailbox/engine
+# action_text/engine
+%w(
+  active_record/railtie
+  active_storage/engine
+  action_controller/railtie
+  action_view/railtie
+  action_mailer/railtie
+  rails/test_unit/railtie
+  sprockets/railtie
+).each do |railtie|
+  begin
+    require railtie
+  rescue LoadError
+  end
+end
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
Neste PR nós removemos `action_cable/engine`, `action_mailbox/engine` e `action_text/engine` da nossa aplicação para reduzir o consumo de memória em produção. Espera-se que a aplicação precise de aproximadamente 40 MiB a menos.