### PR TITLE
Substituindo 'mother_list' para aparecer em radio buttons

### DIFF
--- a/app/views/patients/sessions/new.html.erb
+++ b/app/views/patients/sessions/new.html.erb
@@ -16,8 +16,13 @@
       <%= f.hidden_field :cpf, value: @patient.cpf %>
 
       <div class="form-group" >
-        <%= f.label :password, "Selecione o primeiro nome da sua mãe" %><br />
-        <%= f.select :password, @mother_list, {}, { class: 'form-control' } %>
+        <%= f.label :password, "Selecione o primeiro nome da sua mãe:" %><br />
+        <div style="text-align: left; padding-left: 42%;" >
+          <% @mother_list.each do |mother| %>
+            <%= f.radio_button(:password, mother) %>
+            <%= f.label(:password, mother) %><br/>
+          <% end %>
+        </div>
       </div>
 
       <div class="actions">


### PR DESCRIPTION
Neste PR realizamos a substituição da _drop-down list_ `mother_list` para _radio button_ na view `patients/session/new.html`.

Essa alteração foi sugerida pelos servidores do município de Joinville que observaram que algumas pessoas estavam sendo bloqueadas por não conseguirem perceber que se tratava de uma lista onde era necessário clicar em cima para aparecer mais opções. Com a alteração, fica visível de imediato aparecendo todos os nomes, ficando mais claro para o usuário que deve escolher o nome de sua mãe, que aparece entre as opções.

**Versão Desktop:**
![Screenshot from 2020-10-22 23-15-17](https://user-images.githubusercontent.com/19494561/96950393-928e2e80-14c0-11eb-8987-b3824c38b35e.png)

**Versão Mobile:**
![Screenshot from 2020-10-22 23-15-55](https://user-images.githubusercontent.com/19494561/96950483-ccf7cb80-14c0-11eb-8881-e7ef08d80f70.png)

