### PR TITLE
Refatoração do TimeSlotContoller com paginação por dia

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -26,6 +26,10 @@ class Patient < ApplicationRecord
     appointments.select(&:active?)
   end
 
+  def current_appointment
+    active_appointments.last
+  end
+
   def set_main_ubs
     self.main_ubs =
       # samples an active ubs near the patient neighborhood

--- a/app/views/time_slot/index.html.erb
+++ b/app/views/time_slot/index.html.erb
@@ -95,7 +95,7 @@
       </div>
       <div class="row">
         <div class="col">
-          <% @time_slots.each do |ubs, days| %>
+          <% @time_slots.each do |ubs, slots| %>
             <div id=<%= "ubsId#{ubs.id}Accordion" %>>
               <div class="card">
                 <div class="card-header" id=<%= "ubsId#{ubs.id}" %>>
@@ -105,42 +105,27 @@
                     </button>
                   </h5>
                 </div>
-
                 <div id=<%= "ubsControl#{ubs.id}" %> class="collapse" aria-labelledby=<%= "ubsId#{ubs.id}" %> data-parent=<%= "#ubsId#{ubs.id}Accordion" %>>
                   <div class="card-body">
-                    <% days.each do |day, slots| %>
-                      <div id=<%= "day#{ubs.id}Id#{day.to_s}Accordion" %>>
-                        <div class="card">
-                          <div class="card-header" id=<%= "day#{ubs.id}Id#{day.to_s}" %>>
-                            <button class="btn btn-link" data-toggle="collapse" data-target=<%= "#day#{ubs.id}Control#{day.to_s}" %> aria-expanded="true" aria-controls=<%= "day#{ubs.id}Control#{day.to_s}" %>>
-                              <%= ApplicationHelper.humanize_date(day) %>
-                            </button>
+                    <div class="container">
+                      <% slots.each do |slot| %>
+                        <div class="row">
+                          <div class="col align-middle">
+                            Horário <br /> <%= ApplicationHelper.humanize_time(slot[:slot_start]) %>
                           </div>
-                          <div id=<%= "day#{ubs.id}Control#{day.to_s}" %> class="collapse" aria-labelledby=<%= "day#{ubs.id}Id#{day.to_s}" %> data-parent=<%= "#day#{ubs.id}Id#{day.to_s}Accordion" %>>
-                            <div class="card-body">
-                              <div class="container">
-                                <% slots.each do |slot| %>
-                                  <div class="row">
-                                    <div class="col align-middle">
-                                      Horário <br /> <%= ApplicationHelper.humanize_time(slot[:slot_start]) %>                                      </div>
-                                    <div class="col text-right">
-                                      <%= button_to @appointment.present? ? 'Substituir' : 'Agendar', schedule_time_slot_path(start_time: slot[:slot_start], ubs_id: ubs.id), class: "btn btn-success" %>
-                                    </div>
-                                  </div>
-                                  <hr/>
-                                <% end %>
-                              </div>
-                            </div>
+                          <div class="col text-right">
+                            <%= button_to @appointment.present? ? 'Substituir' : 'Agendar', schedule_time_slot_path(start_time: slot[:slot_start], ubs_id: ubs.id), class: "btn btn-success" %>
                           </div>
                         </div>
-                      </div>
-                    <% end %>
+                        <hr/>
+                      <% end %>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
-            <br/>
           <% end %>
+          <br/>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Olá! Fui atacar a issue https://github.com/MakersNetwork/agenda-saude/issues/79 mas depois de mexer um tanto no código, percebi que já temos um bom fix onde carregamos sempre um dia por vez.

Porém notei que a interface ainda mostrava um card para o dia, de forma que o usuário tem que clicar no dia antes de escolher o horário, o que não é mais necessário com a mudança de paginação.

Era:
![image](https://user-images.githubusercontent.com/18356186/97374292-be316000-1896-11eb-83bf-49ed0094f657.png)
Ficou:
![image](https://user-images.githubusercontent.com/18356186/97374326-cc7f7c00-1896-11eb-9fda-673efd8e7a63.png)

E já vou linkar aqui pra fechar a issue: fixes https://github.com/MakersNetwork/agenda-saude/issues/79