### PR TITLE
Caixa de seleção para escolha de data de nacimento

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -28,3 +28,15 @@ $blue: #005293;
   width: 100%;
   height: auto;
 }
+
+.day {
+  width: 25%;
+}
+
+.month {
+  width: 45%;
+}
+
+.year {
+  width: 30%;
+}

--- a/app/controllers/patients/registrations_controller.rb
+++ b/app/controllers/patients/registrations_controller.rb
@@ -25,11 +25,10 @@ class Patients::RegistrationsController < Devise::RegistrationsController
     fields = params.require(:patient).permit(*FIELDS)
     fields[:bedridden] = false
     fields[:target_audience] = Patient.target_audiences["without_target"]
+    fields = convert_birth_date(fields)
 
     patient = Patient.new(fields)
     patient.last_appointment = nil
-
-    patient.validate_year
 
     # return render 'patients/not_allowed' unless patient.allowed_age?
 
@@ -49,6 +48,17 @@ class Patients::RegistrationsController < Devise::RegistrationsController
     @cpf = params[:cpf]
 
     super
+  end
+
+  private
+
+  def convert_birth_date(fields)
+    day = fields.delete("birth_date(3i)")
+    month = fields.delete("birth_date(2i)")
+    year = fields.delete("birth_date(1i)")
+
+    fields[:birth_date] = '%04d-%02d-%02d' % [year, month, day]
+    fields
   end
 
   # POST /resource

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -89,22 +89,4 @@ class Patient < ApplicationRecord
 
     return true
   end
-
-  def validate_year
-    p_year = birth_date[0..3].to_i
-    p_month = birth_date[5..6].to_i
-    p_day = birth_date[8..9].to_i
-
-    if p_year < 1850
-      if p_year > 20
-        p_year = p_year + 1900
-      else
-        p_year = p_year + 2000
-      end
-
-      new_birth_date = '%04d-%02d-%02d' % [p_year, p_month, p_day]
-      update!(birth_date: new_birth_date)
-    end
-  end
-
 end

--- a/app/views/patients/registrations/new.html.erb
+++ b/app/views/patients/registrations/new.html.erb
@@ -38,7 +38,9 @@
   <div class="form-row">
     <div class="form-group col-md-4">
       <%= f.label :birth_date, "Data de nascimento" %>
-      <%= f.date_field :birth_date, autofocus: true, autocomplete: "birth_date", required: true, class: "form-control" %>
+      <div class="form-row">
+        <%= f.date_select :birth_date, { start_year: 1900, with_css_classes: true } , autofocus: true, autocomplete: "birth_date", required: true, class: "form-control" %>
+      </div>
     </div>
 
     <div class="form-group col-md-4">

--- a/config/locales/views.pt-BR.yml
+++ b/config/locales/views.pt-BR.yml
@@ -16,6 +16,12 @@ pt-BR:
     models:
       user: Usuário
       patient: Paciente
+  date:
+    order:
+      - :day
+      - :month
+      - :year
+    month_names: ['Janeiro', 'Fevereiro', 'Março', 'Abril', 'Maio', 'Junho', 'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro']
   errors:
     messages:
       not_saved:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -78,8 +78,8 @@ today = Date.today
   patient = Patient.new
   patient.name = "marvin#{i}"
   patient.cpf = cpfs[i]
-  patient.mother_name = 'num sei'
-  patient.birth_date = '01/01/1980'
+  patient.mother_name = 'Natureza'
+  patient.birth_date = '1979-06-24'
   patient.phone = '12345678'
   patient.neighborhood = 'América'
   patient.save!


### PR DESCRIPTION
Olá :octocat: 

Essa é uma melhoria na escolha de data de nascimento, que estava sendo um problema para os usuários, principalmente no celular, gerando dados incorretos e com formatação inválida. Fixes https://github.com/MakersNetwork/agenda-saude/issues/52

A solução proposta é o uso das caixas de seleção estilo dropdown que são mais comuns e tradicionais para escolhas de data.

A própria seleção se limita ao ano 1900, então a validação para anos muito antigos foi removida.

## Como

Usando o helper [date_select](https://apidock.com/rails/ActionView/Helpers/DateHelper/date_select#825-Passing-html-options-Ruby-hash-parameters-) do rails, que automaticamente gera os três menus dropdown e agrega os resultados. Assim, ao permitir o campo `:birth_date`, os seguintes dados são retornados de `params`:
```ruby
{ ... , "birth_date(3i)"=>"31", "birth_date(2i)"=>"10", "birth_date(1i)"=>"2020", ... }
```

E portanto é necessária uma conversão manual desse formato para o formato da ISO que utilizamos no banco.

## Resultado

Era:

![image](https://user-images.githubusercontent.com/18356186/97790363-eecf0d80-1ba6-11eb-9256-2c76b6250bc7.png)

Ficou:

![image](https://user-images.githubusercontent.com/18356186/97790347-bcbdab80-1ba6-11eb-8238-ec827072521c.png)

