### PR TITLE
Consertando o problema que estava acontecendo ao substituir um agendamento

### DIFF
--- a/app/controllers/time_slot_controller.rb
+++ b/app/controllers/time_slot_controller.rb
@@ -17,6 +17,12 @@ class TimeSlotController < PatientSessionController
         return
       end
 
+      if Appointment.where("patient_id = ? AND start > ?", current_patient.id, Time.zone.now).last != nil
+        Appointment.where("patient_id = ? AND start > ?", current_patient.id, Time.zone.now).find_each do |appointment|
+          appointment.destroy
+        end
+      end
+
       @appointment = Appointment.create(
         patient: current_patient,
         ubs: @ubs,
@@ -38,6 +44,12 @@ class TimeSlotController < PatientSessionController
   def cancel
     @appointment = Appointment.find(cancel_params[:appointment_id])
     @appointment.destroy
+
+    if Appointment.where("patient_id = ? AND start > ?", current_patient.id, Time.zone.now).last != nil
+      Appointment.where("patient_id = ? AND start > ?", current_patient.id, Time.zone.now).find_each do |appointment|
+        appointment.destroy
+      end
+    end
 
     @patient = Patient.find(current_patient.id)
     @patient.last_appointment = nil

--- a/app/controllers/time_slot_controller.rb
+++ b/app/controllers/time_slot_controller.rb
@@ -17,11 +17,7 @@ class TimeSlotController < PatientSessionController
         return
       end
 
-      if Appointment.where("patient_id = ? AND start > ?", current_patient.id, Time.zone.now).last != nil
-        Appointment.where("patient_id = ? AND start > ?", current_patient.id, Time.zone.now).find_each do |appointment|
-          appointment.destroy
-        end
-      end
+      current_patient.appointments.futures.destroy_all
 
       @appointment = Appointment.create(
         patient: current_patient,
@@ -44,12 +40,6 @@ class TimeSlotController < PatientSessionController
   def cancel
     @appointment = Appointment.find(cancel_params[:appointment_id])
     @appointment.destroy
-
-    if Appointment.where("patient_id = ? AND start > ?", current_patient.id, Time.zone.now).last != nil
-      Appointment.where("patient_id = ? AND start > ?", current_patient.id, Time.zone.now).find_each do |appointment|
-        appointment.destroy
-      end
-    end
 
     @patient = Patient.find(current_patient.id)
     @patient.last_appointment = nil

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -6,6 +6,8 @@ class Appointment < ApplicationRecord
     where('start >= ? AND appointments.end <= ?', day.beginning_of_day, day.end_of_day)
   end
 
+  scope :futures, -> { where('start > ?', Time.current) }
+
   def active?
     active == true
   end


### PR DESCRIPTION
Olá a todos(as),

Neste PR consertamos o problema que estava ocorrendo de quando um paciente que já tinha um agendamento marcado, clicava em algum outro horário disponível para substituir o agendamento anterior.

Problema que ocorre é que o agendamento anterior não é excluído, mantendo ocupada um horário que deveria ter ficado disponível com a substituição.

Outro erro que ocorre em decorrência deste primeiro, é ao cancelar o agendamento, é necessário um por um dos *n* agendamentos futuros que o paciente tenha se agendado, ao invés de excluir todos os agendamentos futuros de uma só vez.

### Problema
A animação abaixo exemplifica os erros mencionados:
![video_01_erro](https://user-images.githubusercontent.com/19494561/101109037-b3b06780-35b4-11eb-8965-a41acc474675.gif)

### Solução
A solução proposta para os erros citados acima é ilustrada na animação a seguir:
![video_02_feito](https://user-images.githubusercontent.com/19494561/101109739-51586680-35b6-11eb-98d2-24915460cf36.gif)


Não existe uma *issue* aberta para este problema.

