### PR TITLE
Adiciona botão para UBS poder exportar agendamentos do dia

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,9 @@ gem 'tod'
 
 gem 'newrelic_rpm'
 
+gem 'caxlsx'
+gem 'caxlsx_rails'
+
 group :development, :test do
   gem 'byebug'
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,14 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.1.3)
+    caxlsx (3.0.3)
+      htmlentities (~> 4.3, >= 4.3.4)
+      mimemagic (~> 0.3)
+      nokogiri (~> 1.10, >= 1.10.4)
+      rubyzip (>= 1.3.0, < 3)
+    caxlsx_rails (0.6.2)
+      actionpack (>= 3.1)
+      caxlsx (>= 3.0)
     code_analyzer (0.5.2)
       sexp_processor
     coderay (1.1.3)
@@ -142,6 +150,7 @@ GEM
     has_scope (0.7.2)
       actionpack (>= 4.1)
       activesupport (>= 4.1)
+    htmlentities (4.3.4)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     inherited_resources (1.11.0)
@@ -297,6 +306,7 @@ GEM
     ruby_dep (1.5.0)
     ruby_parser (3.15.0)
       sexp_processor (~> 4.9)
+    rubyzip (2.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -352,6 +362,8 @@ DEPENDENCIES
   brakeman
   bullet
   byebug
+  caxlsx
+  caxlsx_rails
   cpf_cnpj
   devise
   factory_bot_rails

--- a/app/controllers/ubs_controller.rb
+++ b/app/controllers/ubs_controller.rb
@@ -10,6 +10,17 @@ class UbsController < UserSessionController
     @bedridden_patients = @ubs.bedridden_patients
   end
 
+  def today_appointments
+    @appointments = @ubs.appointments.today.order(:start)
+
+    respond_to do |format|
+      format.xlsx {
+        response.headers['Content-Disposition'] =
+          "attachment; filename=\"agendamentos_#{Date.current}.xlsx\""
+      }
+    end
+  end
+
   def activate_ubs
     updated = @ubs.update(active: true)
 

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -2,6 +2,7 @@ class Appointment < ApplicationRecord
   belongs_to :patient
   belongs_to :ubs
 
+  scope :today, -> { where('date(start) = ?', Date.current) }
   scope :active_from_day, ->(day) do
     where('start >= ? AND appointments.end <= ?', day.beginning_of_day, day.end_of_day)
   end

--- a/app/views/ubs/index.html.erb
+++ b/app/views/ubs/index.html.erb
@@ -65,11 +65,19 @@
     <% end %>
     </tbody>
     </table>
+
     <p>
-    <a class="btn btn-danger" href=<%= "/ubs/#{@ubs.id}/cancel_all_future_appointments" %>
-    onclick="return confirm('Você tem certeza?')">Desativar todos agendamentos futuros</a>
-    <a class="btn btn-success" href=<%= "/ubs/#{@ubs.id}/activate_all_future_appointments" %>
-    onclick="return confirm('Você tem certeza?')">Ativar todos agendamentos futuros</a><br/>
+      <%= link_to 'Exportar agendamentos do dia',
+                  today_appointments_ubs_path(@ubs, format: 'xlsx'),
+                  class: 'btn btn-primary' %>
+      <%= link_to 'Desativar todos agendamentos futuros',
+                  cancel_all_future_appointments_ubs_path(@ubs),
+                  class: 'btn btn-danger',
+                  data: { confirm: 'Você tem certeza?' } %>
+      <%= link_to 'Ativar todos agendamentos futuros',
+                  activate_all_future_appointments_ubs_path(@ubs),
+                  class: 'btn btn-success',
+                  data: { confirm: 'Você tem certeza?' } %>
     </p>
   <% else %>
     <p>Nenhum paciente agendou horário até o momento.</p>

--- a/app/views/ubs/today_appointments.xlsx.axlsx
+++ b/app/views/ubs/today_appointments.xlsx.axlsx
@@ -6,14 +6,15 @@ xlsx_package.workbook.add_worksheet do |sheet|
 
   @appointments.each_with_index do |appointment, index|
     patient = appointment.patient
+    birth_date = Date.parse patient.birth_date
 
     sheet.add_row [
         index,
-        l(appointment.start, format: :american),
+        l(appointment.start, format: :default),
         patient.name,
         patient.cpf,
         patient.phone,
-        patient.birth_date,
+        l(birth_date, format: :default),
         patient.public_place,
         patient.place_number,
         patient.neighborhood

--- a/app/views/ubs/today_appointments.xlsx.axlsx
+++ b/app/views/ubs/today_appointments.xlsx.axlsx
@@ -1,0 +1,22 @@
+headers = ['', 'Agenda_Inicio', 'Nome', 'CPF', 'Telefone',
+           'Data_Nascimento', 'Rua', 'Numero', 'Bairro']
+
+xlsx_package.workbook.add_worksheet do |sheet|
+  sheet.add_row headers
+
+  @appointments.each_with_index do |appointment, index|
+    patient = appointment.patient
+
+    sheet.add_row [
+        index,
+        l(appointment.start, format: :american),
+        patient.name,
+        patient.cpf,
+        patient.phone,
+        patient.birth_date,
+        patient.public_place,
+        patient.place_number,
+        patient.neighborhood
+      ]
+  end
+end

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -2,3 +2,4 @@
 
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
+Mime::Type.register "application/xlsx", :xlsx

--- a/config/locales/views.pt-BR.yml
+++ b/config/locales/views.pt-BR.yml
@@ -22,9 +22,11 @@ pt-BR:
       - :month
       - :year
     month_names: ['Janeiro', 'Fevereiro', 'Março', 'Abril', 'Maio', 'Junho', 'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro']
+    formats:
+      default: '%d/%m/%Y'
   time:
       formats:
-        american: '%Y-%m-%d %H:%M'
+        default: '%d/%m/%Y %H:%M'
   errors:
     messages:
       not_saved:

--- a/config/locales/views.pt-BR.yml
+++ b/config/locales/views.pt-BR.yml
@@ -22,6 +22,9 @@ pt-BR:
       - :month
       - :year
     month_names: ['Janeiro', 'Fevereiro', 'Março', 'Abril', 'Maio', 'Junho', 'Julho', 'Agosto', 'Setembro', 'Outubro', 'Novembro', 'Dezembro']
+  time:
+      formats:
+        american: '%Y-%m-%d %H:%M'
   errors:
     messages:
       not_saved:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
       get 'activate_all_future_appointments'
       get 'activate_ubs'
       get 'deactivate_ubs'
+      get 'today_appointments'
     end
   end
 


### PR DESCRIPTION
Nesse PR eu adicionei um botão para possibilitar a UBS exportar os agendamentos do dia atual para CSV.

Me baseei no modelo de planilha anexado no  [Card](https://trello.com/c/KmO8GFSM/109-melhorar-a-visualiza%C3%A7%C3%A3o-de-agendamentos-na-vis%C3%A3o-do-operador).

## Links

- Card: [159](https://trello.com/c/KmO8GFSM/109-melhorar-a-visualiza%C3%A7%C3%A3o-de-agendamentos-na-vis%C3%A3o-do-operador)

## :computer: SCREENSHOTS

Botão adicionado
![2020-12-28_07-26](https://user-images.githubusercontent.com/31210460/103207941-473c3600-48de-11eb-88b2-e4387b2a0417.png)