### PR TITLE
Create appointments per slots

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ group :development, :test do
   gem 'rspec'
   gem 'rspec-rails'
   gem 'factory_bot_rails'
+  gem 'smarter_csv'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,7 +347,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (>= 6)
   sentry-raven (~> 3.0)
-  smarter_csv (~> 1.2)
+  smarter_csv
   spring
   spring-watcher-listen (~> 2.0.0)
   stackprof

--- a/db/migrate/20210115144558_add_appointments_per_slot_to_ubss.rb
+++ b/db/migrate/20210115144558_add_appointments_per_slot_to_ubss.rb
@@ -1,0 +1,5 @@
+class AddAppointmentsPerSlotToUbss < ActiveRecord::Migration[6.0]
+  def change
+    add_column :ubs, :appointments_per_time_slot, :integer, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_11_010618) do
+ActiveRecord::Schema.define(version: 2021_01_15_144558) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,6 +77,7 @@ ActiveRecord::Schema.define(version: 2020_05_11_010618) do
     t.string "address", default: ""
     t.string "cnes"
     t.boolean "active", default: false
+    t.integer "appointments_per_time_slot", default: 1
     t.index ["cnes"], name: "index_ubs_on_cnes", unique: true
     t.index ["user_id"], name: "index_ubs_on_user_id"
   end


### PR DESCRIPTION
## Need to fix this to point to main :stuck_out_tongue: 

Here we add the `appointments_per_slot` field to UBS's. This serves the purpose of enabling a UBS to have more than one appointment in the same time slot.

## :squirrel: TESTS

### SCENARIO ONE

Describe the test scenario the reviewer show execute in staging to test the new feature or the bug fix.

1. Enter the local container, after docker is up with: `docker exec -it agenda-saude_web_1 /bin/bash`
2. Run `bundle exec rails db:migrate`
3. Enter `rails console`

The UBS shall have a new attribute called `appointments_per_slot` with a default value of 1.

## :package: DEPLOY

After the code is merged we need to run the migration on Heroku, not sure if we need a new deploy. So:

1 - merge the PR
2 - `heroku run rails db:migrate`
3(?) - `git push heroku master`