### PR TITLE
Create appointments per time slot field

### DIFF
--- a/app/controllers/ubs_controller.rb
+++ b/app/controllers/ubs_controller.rb
@@ -122,10 +122,11 @@ class UbsController < UserSessionController
 
   def active_hours_params
     params.require(:ubs).permit(:shift_start_date, :shift_end_date, :break_start_date, :break_end_date,
-    :shift_start_saturday, :break_start_saturday, :break_end_saturday, :shift_end_saturday, :open_saturday)
+                                :shift_start_saturday, :break_start_saturday, :break_end_saturday,
+                                :shift_end_saturday, :open_saturday)
   end
 
   def slot_duration_params
-    params.require(:ubs).permit(:slot_interval_minutes)
+    params.require(:ubs).permit(:slot_interval_minutes, :appointments_per_time_slot)
   end
 end

--- a/app/models/ubs.rb
+++ b/app/models/ubs.rb
@@ -3,6 +3,7 @@ class Ubs < ApplicationRecord
 
   validate :times_must_be_ordered
   validates :slot_interval_minutes, inclusion: 1...120
+  validates :appointments_per_time_slot, numericality: { greater_than: 0 }
 
   belongs_to :user
   has_many :appointments, dependent: :destroy

--- a/app/views/ubs/slot_duration.html.erb
+++ b/app/views/ubs/slot_duration.html.erb
@@ -11,13 +11,24 @@
 <%= form_for @ubs, url: ubs_change_slot_duration_path do |f| %>
   <div class="field">
     <%= f.label :slot_interval_minutes, 'Duração de cada atendimento (em minutos):' %><br />
-    <% if @ubs.active %>
-      <%= f.number_field :slot_interval_minutes, disabled: 'disabled' %>
+    <div class="form-group col-md-4">
+      <% if @ubs.active %>
+        <%= f.number_field :slot_interval_minutes, disabled: 'disabled' %>
     <% else %>
-      <div class="form-group col-md-4">
-        <%= f.select :slot_interval_minutes, [5, 10, 15, 20, 30, 45, 60], {},  { class: "form-control" } %>
-      </div>
+        <%= f.select :slot_interval_minutes, [5, 10, 15, 20, 30, 45, 60], {}, { class: "form-control" } %>
     <% end %>
+    </div>
+  </div>
+
+  <div class="field">
+    <%= f.label :appointments_per_time_slot, 'Número de atendimentos por horário:' %><br />
+    <div class="form-group col-md-4">
+      <% if @ubs.active %>
+        <%= f.number_field :appointments_per_time_slot, disabled: 'disabled' %>
+      <% else %>
+        <%= f.number_field :appointments_per_time_slot, { min: 1, class: "form-control" }  %>
+      <% end %>
+    </div>
   </div>
 
   <div class="d-flex mt-3">

--- a/db/migrate/20210115151930_add_appointments_per_slot_to_ubss.rb
+++ b/db/migrate/20210115151930_add_appointments_per_slot_to_ubss.rb
@@ -1,0 +1,5 @@
+class AddAppointmentsPerSlotToUbss < ActiveRecord::Migration[6.0]
+  def change
+    add_column :ubs, :appointments_per_time_slot, :integer, default: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_02_042929) do
+ActiveRecord::Schema.define(version: 2021_01_15_151930) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,6 +85,7 @@ ActiveRecord::Schema.define(version: 2020_10_02_042929) do
     t.string "saturday_break_start"
     t.string "saturday_break_end"
     t.string "saturday_shift_end"
+    t.integer "appointments_per_time_slot", default: 1
     t.index ["cnes"], name: "index_ubs_on_cnes", unique: true
     t.index ["user_id"], name: "index_ubs_on_user_id"
   end


### PR DESCRIPTION
Aqui adicionamos o campo `appointments_per_time_slot` nas UBS, que deverá permitir uma UBS executar mais de um atendimento ao mesmo tempo.

1. Quando a UBS está desativada, permite alterar o campo
![image](https://user-images.githubusercontent.com/18356186/104928142-0f765a80-5981-11eb-87f8-3bf4a548f9d2.png)

2. Quando a UBS está ativada, apenas exibe o valor
![image](https://user-images.githubusercontent.com/18356186/104928241-29b03880-5981-11eb-816e-f4922f26cf9d.png)

## Validações

- Não permite valores abaixo de 1 (view + model)
