### PR TITLE
Status de agendamento na página inicial

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,38 +1,58 @@
 <div class="row text-center">
   <div class="col">
-    <p class="h4">Agendamento para o teste rápido da COVID-19 em Joinville</p>
+    <p class="h4">Agendar Vacinação Covid-19</p>
   </div>
 </div>
 
-<div class="alert alert-info alert-dismissable mb-5 mt-5" role="alert">
-  <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-  <h6 class="mb-0" style="text-align: center;">
-    Os <strong>Testes Rápidos</strong> que estão sendo disponibilizados pela Secretaria da Saúde são para <strong>pessoas assintomáticas</strong> e de adesão voluntária. <strong>Somente serão agendados ou cancelados através desse canal</strong>.<br/><br/>
+<table class="table table-bordered center", style="width: 70%; margin-top: 10px; margin-left: auto; margin-right: auto;">
+  <thead>
+    <tr>
+      <th scope="col">STATUS DO AGENDAMENTO</th>
+      <th scope="col">GRUPOS QUE PODEM AGENDAR</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <% if Appointment.where('patient_id IS NULL AND start > ?', Time.zone.now).count > 0 %>
+          <i class="fa fa-circle" aria-hidden="true" style="color: green;"></i> Em aberto
+        <% elsif Ubs.where(active: true) %>
+          <i class="fa fa-circle" aria-hidden="true" style="color: red;"></i> SEM HORÁRIO DISPONÍVEL
+        <% else %>
+          <i class="fa fa-circle" aria-hidden="true" style="color: red;"></i> Sem estoque
+        <% end %>
+      </td>
+      <td>
+        <% Patient::CONDITIONS.each do |name, _| %>
+          <i class="fa fa-check-circle" aria-hidden="true" style="color: green;"></i> <%= name %><br>
+        <% end %>
+      </td>
+    </tr>
+      </tbody>
+</table>
 
-    Reiteramos que os <strong>Testes Rápidos não são indicados para pessoas sintomáticas</strong>, por isso, caso esteja com sintomas, <strong>procure uma Unidade de Saúde</strong> para uma avaliação presencial.<br/><br/>
+<p>Este é o sistema para agendamento da vacinação contra o Covid-19 que acontece na Central de Imunização no Centreventos.</p>
+<p><i>* O sistema de vacinação mostra o "status do agendamento" e os grupos que podem agendar no momento, dada ainda a ordem dos grupos prioritários.
+  A vacinação é liberada para cada pessoa dao status acima e ordem dos grupos prioriários.</i></p>
 
-    Caso <strong>você ou alguém de sua residência esteja cumprindo período de isolamento</strong> após confirmação de diagnóstico de Covid-19, <strong>cancele seu exame</strong> caso tenha agendado e <strong>aguarde 10 dias para agendá-lo novamente</strong>.<br/><br/>
+<div class="card">
+  <div class="card-body">
+    <h5 class="card-title">Iniciar Agendamento</h5>
+    <p class="card-text"><b>CENTREVENTOS CAU HANSEN</b><br>
+      Av. José Vieira, 315 - América, Joinville - SC, 89204-110<br>
+      Telefone: (47) 3422-5951
+</p>
 
-    Um <strong>resultado positivo</strong> (IgG ou IgM), indica apenas contato anterior com o vírus, <strong>não sendo garantia de imunidade</strong>, logo o <strong>uso de máscara</strong>, a <strong>higiene das mãos</strong> e as medidas de <strong>distanciamento social</strong> precisam ser mantidas, <strong>independente do resultado</strong>.<br/>
-  </h6>
-</div>
-
-<p class="mt-5">Faça seu agendamento abaixo e dirija-se até a unidade escolhida com um documento de identificação em mãos.</p>
-
-
-<div class="row text-center">
-  <div class="col">
     <%= form_for(:patient, url: patient_base_login_path) do |f| %>
-      <div class="form-group">
-        <%= f.text_field :cpf, autofocus: true, autocomplete: "cpf", minlength: 11, maxlength: 11, required: true, class: "form-control", 'aria-describedby' => 'cpfHelpInLine', placeholder: 'CPF', data: { cy: "cpfInputField" } %>
-        <small id="cpfHelpInLine" class="text-muted">
-          Cadastre seu CPF para fazer o agendamento do seu teste rápido para COVID-19
-        </small>
-      </div>
+    <div class="form-row"">
+        <div class="form-group col-md-9">
+          <%= f.text_field :cpf, autofocus: true, autocomplete: "cpf", minlength: 11, maxlength: 11, required: true, class: "form-control", 'aria-describedby' => 'cpfHelpInLine', placeholder: 'CPF', data: { cy: "cpfInputField" } %>
+        </div>
 
-      <div class="actions">
-        <%= f.submit "Entrar", class: "btn btn-primary btn-block", data: { cy: "signUpButton" } %>
-      </div>
+        <div class="form-group col-md-3">
+          <%= f.submit "Agendar Vacinação", class: "btn btn-primary btn-block", data: { cy: "signUpButton" } %>
+        </div>
+    </div>
     <% end %>
   </div>
 </div>
@@ -46,20 +66,20 @@
 <div class="row text-center mt-5 mb-5">
   <div class="col">
     <small class="text-muted">Para mais informações sobre a COVID-19 no município, acesse:<br>
-    <a href="https://www.joinville.sc.gov.br/coronavirus/">https://www.joinville.sc.gov.br/coronavirus/</a></small>
+      <a href="https://www.joinville.sc.gov.br/coronavirus/">https://www.joinville.sc.gov.br/coronavirus/</a></small>
   </div>
 </div>
 
 <style type="text/css">
-  @media only screen and (min-width: 600px) {
-    .disk-health-banner {
-      width: 80%;
-    }
-  }
+ @media only screen and (min-width: 600px) {
+   .disk-health-banner {
+     width: 80%;
+   }
+ }
 
-  @media only screen and (max-width: 600px) {
-    .disk-health-banner {
-      width: 100%;
-    }
-  }
+ @media only screen and (max-width: 600px) {
+   .disk-health-banner {
+     width: 100%;
+   }
+ }
 </style>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -33,7 +33,7 @@
 
 <p>Este é o sistema para agendamento da vacinação contra o Covid-19 que acontece na Central de Imunização no Centreventos.</p>
 <p><i>* O sistema de vacinação mostra o "status do agendamento" e os grupos que podem agendar no momento, dada ainda a ordem dos grupos prioritários.
-  A vacinação é liberada para cada pessoa dao status acima e ordem dos grupos prioriários.</i></p>
+  A vacinação é liberada para cada pessoa do status acima e ordem dos grupos prioritários.</i></p>
 
 <div class="card">
   <div class="card-body">


### PR DESCRIPTION
Olá :octocat: 

Aqui estão algumas melhorias que fiz na tela inicial com base no layout que o Gus propôs.
- Mostramos o status de agendamento com base no número de slots disponíveis e número de unidades ativas
- Mostramos os grupos prioritários com base no campo `CONDITIOS` do modelo do paciente

![image](https://user-images.githubusercontent.com/18356186/105611442-24ddf100-5d94-11eb-9078-c172865a9423.png)
