### PR TITLE
Change some text info in views

### DIFF
--- a/app/assets/javascripts/registration.js
+++ b/app/assets/javascripts/registration.js
@@ -12,3 +12,14 @@ function updateSubGroups(group_id) {
     subGroupsList.hidden = true;
   }
 };
+
+function consentHealthWorker() {
+  var healthWorker = document.getElementById(`patient_groups_8`);
+  var consntTerm = document.getElementById(`consent-health-worker`);
+
+  if(healthWorker.checked) {
+    consntTerm.hidden = false;
+  } else {
+    consntTerm.hidden = true;
+  }
+}

--- a/app/views/patients/registrations/new.html.erb
+++ b/app/views/patients/registrations/new.html.erb
@@ -24,7 +24,8 @@
       O agendamento somente ocorrerá conforme orientações abaixo:<br/><br/>
 
       Neste momento somente Trabalhadores de Saúde ativos e que atuam no município de Joinville podem se cadastrar. <br />
-      O pré-cadastro vai até dia <strong>02/02/2021</strong>, após esta data, a Prefeitura vai informar sobre o início dos agendamentos no site, nas redes sociais e pela Imprensa.
+      O pré-cadastro vai até dia <strong>03/02/2021</strong> até o meio dia.<br/>
+      E após às 18:00 do mesmo dia, será liberado o agendamento para o primeiro grupo, conforme informação publicada neste site.
     </h5>
   </div>
 

--- a/app/views/patients/registrations/new.html.erb
+++ b/app/views/patients/registrations/new.html.erb
@@ -20,22 +20,18 @@
 
   <div class="alert alert-info alert-dismissable mb-5 mt-5" role="alert">
     <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
-    <h6 class="mb-0" style="text-align: center;">
+    <h5 class="mb-0" style="text-align: center;">
       O agendamento somente ocorrerá conforme orientações abaixo:<br/><br/>
 
-      <strong>&middot Somente moradores assintomáticos de Joinville</strong> podem realizar o teste;<br/>
-      <strong>&middot Menores de 2 anos não podem fazer o Teste Rápido</strong>;<br/>
-      <strong>&middot</strong> É obrigatório o <strong>CPF e Cartão SUS (CNS)</strong> para agendar e fazer o teste;<br/>
-      <strong>&middot</strong> Verifique <strong>o número de seu Cartão SUS (CNS)</strong> em <a href="https://conectesus-paciente.saude.gov.br">https://conectesus-paciente.saude.gov.br</a>;<br/>
-      <strong>&middot</strong> Geralmente, os planos de saúde mostram o número do Cartão SUS (CNS) no verso da carteirinha;<br/>
-      <strong>&middot</strong> Caso <strong>não tenha Cartão SUS (CNS)</strong>, dirija-se a uma <strong>Unidade de Saúde</strong> para fazer seu.<br/>
-    </h6>
+      Neste momento somente Trabalhadores de Saúde ativos e que atuam no município de Joinville podem se cadastrar. <br />
+      O pré-cadastro vai até dia <strong>02/02/2021</strong>, após esta data, a Prefeitura vai informar sobre o início dos agendamentos no site, nas redes sociais e pela Imprensa.
+    </h5>
   </div>
 
   <h3 class="text-center">Dados Pessoais</h3>
   <div class="form-row">
     <div class="form-group col-md-6">
-      <%= f.label :name, "Nome Completo" %>
+      <%= f.label :name, "Nome Completo" %> <b style="color: red;">*</b>
       <%= f.text_field :name, autofocus: true, autocomplete: "name", required: true, class: "form-control", data: { cy: "newPatientNameInputField" } %>
     </div>
 
@@ -47,7 +43,7 @@
 
   <div class="form-row">
     <div class="form-group col-md-6">
-      <%= f.label :birth_date, "Data de nascimento" %>
+      <%= f.label :birth_date, "Data de nascimento" %> <b style="color: red;">*</b>
       <div class="form-row">
         <%
           start_year = (Date.current.year.to_i) - 18
@@ -57,7 +53,7 @@
     </div>
 
     <div class="form-group col-md-6">
-      <%= f.label :mother_name, "Nome da mãe" %>
+      <%= f.label :mother_name, "Nome da mãe" %> <b style="color: red;">*</b>
       <%= f.text_field :mother_name, autofocus: true, autocomplete: "mother_name", required: true, class: "form-control", data: { cy: "newPatientMotherNameInputField" } %>
     </div>
   </div>
@@ -68,7 +64,7 @@
       <div class="form-check">
         <%= f.collection_check_boxes :groups, Group.where(parent_group_id: nil), :id, :name do |b| %>
           <div class="row">
-            <%= b.label { b.check_box(checked: @patient.groups.map(&:id).include?(b.value), class: "form-check-input", onclick: "updateSubGroups(#{b.value});") + b.text }%>
+            <%= b.label { b.check_box(checked: @patient.groups.map(&:id).include?(b.value), class: "form-check-input", onclick: "updateSubGroups(#{b.value}); consentHealthWorker();") + b.text }%>
           </div>
 
           <% if Group.where(parent_group_id: b.value).any? %>
@@ -86,6 +82,12 @@
           <% end %>
         <% end %>
       </div>
+
+      <div class="form-row" hidden=true id="<%= "consent-health-worker" %>">
+        <div class="col-md-8" style="color: red;">
+          <b>Atenção:</b> Para receber a vacina, será necessário apresentar a comprovação de vínculo ativo em algum estabelecimento de saúde na cidade de Joinville.
+        </div>
+      </div>
     </div>
 
     <div class="form-group col-md-6">
@@ -98,24 +100,24 @@
 
   <div class="form-row">
     <div class="form-group col-md-6">
-      <%= f.label :public_place, "Endereço (Rua, Avenida)" %>
+      <%= f.label :public_place, "Endereço (Rua, Avenida)" %> <b style="color: red;">*</b>
       <%= f.text_field :public_place, autofocus: true, autocomplete: "place", required: true, class: "form-control", data: { cy: "newPatientStreetNameInputField" } %>
     </div>
 
     <div class="form-group col-md-2">
-      <%= f.label :place_number, "Número" %>
+      <%= f.label :place_number, "Número" %> <b style="color: red;">*</b>
       <%= f.text_field :place_number, autofocus: true, required: true, class: "form-control", data: { cy: "newPatientStreetNumberInputField" } %>
     </div>
 
     <div class="form-group col-md-4">
-      <%= f.label :neighborhood, "Bairro" %>
+      <%= f.label :neighborhood, "Bairro" %> <b style="color: red;">*</b>
       <%= f.select :neighborhood, Neighborhood.pluck(:name), {}, { class: "form-control", data: { cy: "newPatientNeighborhoodNameInputField" } } %>
     </div>
   </div>
 
   <div class="form-row">
     <div class="form-group col-md-6">
-      <%= f.label :phone, "Telefone" %>
+      <%= f.label :phone, "Telefone" %> <b style="color: red;">*</b>
       <%= f.text_field :phone, autofocus: true, autocomplete: "phone", required: true, class: "form-control sp-celphones", data: { cy: "newPatientPhoneNumberInputField" } %>
     </div>
 
@@ -124,6 +126,8 @@
       <%= f.text_field :other_phone, autofocus: true, autocomplete: "other_phone", required: false, class: "form-control sp-celphones", data: { cy: "newPatientOtherPhoneNumberInputField" } %>
     </div>
   </div>
+
+  <b style="color: red;">* Campos obrigatórios</b>
 
   <div class="form-row">
     <div class="form-group col-md-6">

--- a/app/views/patients/sessions/new.html.erb
+++ b/app/views/patients/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <div class="row text-center mb-5">
   <div class="col">
-    <p class="h4">Atendimento para COVID-19 em Joinville</p>
+    <p class="h4">Validação do usuário para ver seu agendamento para a vacina contra a COVID-19</p>
   </div>
 </div>
 

--- a/app/views/patients/successfull_schedule.html.erb
+++ b/app/views/patients/successfull_schedule.html.erb
@@ -7,7 +7,8 @@
 <div class="row text-center">
   <div class="col">
     <p class="h8 mb-12">
-      <br/>Dirija-se até a unidade escolhida com <strong>15 minutos de antecedência</strong>, leve um <strong>documento com foto<br/> e seu Cartão SUS (CNS)</strong> e reserve pelo menos <strong>1 hora para o procedimento<strong>.
+      <br/> Dirija-se até a unidade escolhida com <b>15 minutos de antecedência</b>, leve um <b>documento com foto e a Declaração de seu 
+      <br />empregador para comprovar seu vínculo de trabalho</b>. Reserve pelo menos <b>1 hora para o procedimento</b>.
     </p>
   </div>
 </div>
@@ -19,7 +20,6 @@
         <li><strong>Data: </strong><%= ApplicationHelper.humanize_datetime(@appointment.start) %></li>
         <li><strong>Unidade: </strong><%= @ubs.name %></li>
         <li><strong>Endereço: </strong><%= @ubs.address %></li>
-        <li><strong>Telefone: </strong><%= @ubs.phone %></li>
       </ul>
     </div>
   </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -107,10 +107,10 @@ end
 
 [
   'Trabalhador(a) da Saúde',
+  'Portador(a) de comorbidade',
   'Trabalhador(a) da Educação',
   'Trabalhador(a) das Forças de Seguranças e Salvamento',
   'Forças Armadas',
-  'Portador(a) de comorbidade',
   'Trabalhador(a) de transporte coletivo rodoviário de passageiros urbano e de longoprazo',
   'Trabalhador(a) de transporte metroviário e ferroviário',
   'Trabalhador(a) do transporte aéreo',


### PR DESCRIPTION
Olá!

Aqui nesse PR alteramos algumas informações que estavam desatualizadas ou inexistentes:

* `patients/registrations/new.html` (campos obrigatórios e aviso para profissionais da saúde) :

![tela_cadastro_novo](https://user-images.githubusercontent.com/19494561/106402226-462f8480-6407-11eb-818b-a26543a5602f.gif)


* `patients/sessions/new.html` (atualizado o texto inicial):

![Screenshot from 2021-01-31 20-44-39](https://user-images.githubusercontent.com/19494561/106402255-68290700-6407-11eb-9837-27e923895340.png)

* `patients/sucessful_schedule.html` (atualizar informações depois do agendamento confirmado) :grimacing: 