### PR TITLE
Normalize flash[:alert]

### DIFF
--- a/app/views/patients/registrations/edit.html.erb
+++ b/app/views/patients/registrations/edit.html.erb
@@ -1,5 +1,5 @@
 <% if flash[:alert].present? %>
-  <% flash[:alert].each do |msg| %>
+  <% [flash[:alert]].flatten(0).each do |msg| %>
     <div class="alert alert-danger">
       <%= I18n.t("activerecord.models.attributes.#{msg.first}") %>
       <%= msg.second %>


### PR DESCRIPTION
Na dúvida sobre o `flash[:alert]` poder ser tanto `String` quanto `Array`, normalizei para um `Array`.

Corrige a issue [#3](https://sentry.io/organizations/magrathealabs/issues/2191910925) do Sentry (espero).


