### PR TITLE
Adiciona validação para data de nascimento

### DIFF
--- a/app/controllers/patients/registrations_controller.rb
+++ b/app/controllers/patients/registrations_controller.rb
@@ -39,7 +39,7 @@ class Patients::RegistrationsController < Devise::RegistrationsController
     patient.save
 
     return redirect_to home_teste_rapido_path if patient.cpf.blank?
-    return redirect_to new_patient_registration_path(cpf: patient.cpf), alert: patient.errors unless patient.persisted?
+    return redirect_to new_patient_registration_path(cpf: patient.cpf), alert: patient.errors.full_messages unless patient.persisted?
 
     sign_in(patient, scope: :patient)
 
@@ -77,7 +77,7 @@ class Patients::RegistrationsController < Devise::RegistrationsController
 
       redirect_to index_time_slot_path
     else
-      return redirect_to edit_patient_registration_path(@patient), alert: @patient.errors
+      return redirect_to edit_patient_registration_path(@patient), alert: @patient.errors.full_messages
     end
   end
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -22,6 +22,8 @@ class Patient < ApplicationRecord
   validates :phone, presence: true, phone_format: true
   validates :neighborhood, presence: true
 
+  validate :valid_birth_date
+
   after_initialize :set_main_ubs
 
   scope :bedridden, -> { where(bedridden: true) }
@@ -91,5 +93,13 @@ class Patient < ApplicationRecord
 
   def age
     ((Time.zone.now - birth_date.to_time) / 1.year.seconds).floor
+  end
+
+  private
+
+  def valid_birth_date
+    Date.parse(birth_date)
+  rescue ArgumentError
+    errors.add(:birth_date, :invalid)
   end
 end

--- a/app/views/patients/registrations/edit.html.erb
+++ b/app/views/patients/registrations/edit.html.erb
@@ -1,8 +1,7 @@
 <% if flash[:alert].present? %>
-  <% [flash[:alert]].flatten(0).each do |msg| %>
+  <% flash[:alert].each do |msg| %>
     <div class="alert alert-danger">
-      <%= I18n.t("activerecord.models.attributes.#{msg.first}") %>
-      <%= msg.try(:second) %>
+      <%= msg %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/patients/registrations/new.html.erb
+++ b/app/views/patients/registrations/new.html.erb
@@ -1,8 +1,7 @@
 <% if flash[:alert].present? %>
   <% flash[:alert].each do |msg| %>
     <div class="alert alert-danger">
-      <%= I18n.t("activerecord.models.attributes.#{msg.first}") %>
-      <%= msg.second %>
+      <%= msg %>
     </div>
   <% end %>
 <% end %>

--- a/config/locales/models/pt-BR.yml
+++ b/config/locales/models/pt-BR.yml
@@ -26,6 +26,7 @@
                   blank: em branco
                 birth_date:
                   blank: em branco
+                  invalid: inválida
                 phone:
                   blank: em branco
                   invalid: inválido


### PR DESCRIPTION
Nesse PR eu resolvi o problema dos pacientes que estavam se cadastrando com data de nascimento inválida. 

O que foi feito:

- Adicionei uma validação para data de nascimento válida
- Fiz uma mini refatoração na forma como os erros são tratados