### PR TITLE
Fix time slot index view

### DIFF
--- a/app/controllers/time_slot_controller.rb
+++ b/app/controllers/time_slot_controller.rb
@@ -68,6 +68,8 @@ class TimeSlotController < PatientSessionController
           appointments = Appointment.where(start: @current_day.at_beginning_of_day..@current_day.end_of_day, ubs: ubs, patient_id: nil)
         end
 
+        next unless appointments.present?
+
         appointments.each do |appointment|
           slots << { slot_start: appointment.start, slot_end: appointment.end }
         end

--- a/app/controllers/time_slot_controller.rb
+++ b/app/controllers/time_slot_controller.rb
@@ -68,7 +68,7 @@ class TimeSlotController < PatientSessionController
           appointments = Appointment.where(start: @current_day.at_beginning_of_day..@current_day.end_of_day, ubs: ubs, patient_id: nil)
         end
 
-        next unless appointments.present?
+        next unless appointments.exists?
 
         appointments.each do |appointment|
           slots << { slot_start: appointment.start, slot_end: appointment.end }

--- a/app/views/time_slot/index.html.erb
+++ b/app/views/time_slot/index.html.erb
@@ -7,7 +7,7 @@
       </h6>
     </div>
   <% end %>
-  <% if @appointment.present? %>
+  <% if @appointment.present? && @appointment.start > Time.zone.now %>
     <div class="container">
       <div class="card">
         <div class="card-body">
@@ -115,7 +115,7 @@
       <div class="row">
         <div class="col">
           <h4>Agendamentos disponíveis:</h4>
-          <% if @appointment.present? %>
+          <% if @appointment.present? && @appointment.start > Time.zone.now %>
             <div class="alert alert-warning alert-dismissable" role="alert">
             <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
             <h6 class="mb-0">


### PR DESCRIPTION
Olá!

Neste PR é feito modificações na view `time_slot.index.html` para que:

- Não apareça o *card* de agendamento atual se o horário de início do mesmo já passou, impossibilitando que o paciente possa cancelar / substituir este agendamento;
- Não exibir o *Accordion* de uma unidade se a mesma está ativa, porém sem nenhum agendamento disponível para o dia selecionado.

### Antes:

![time_slot_view_before](https://user-images.githubusercontent.com/19494561/106992173-98014300-6756-11eb-9906-7b0610e41452.gif)


### Depois:

![time_slot_view_after](https://user-images.githubusercontent.com/19494561/106992193-a18aab00-6756-11eb-8a39-f21ca2044327.gif)

