### PR TITLE
Extract slack notification stuff

### DIFF
--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -1,0 +1,35 @@
+module SlackNotifier
+  class << self
+    mattr_accessor :slack_webhook_url
+
+    def error(message)
+      send_message("‼️ #{message}")
+    end
+
+    def info(message)
+      send_message("ℹ️ #{message}")
+    end
+
+    def warn(message)
+      send_message("⚠️ #{message}")
+    end
+
+    def success(message)
+      send_message("✅ #{message}")
+    end
+
+    def send_message(text)
+      return if slack_webhook_url.blank?
+
+      uri = URI(slack_webhook_url)
+      https = Net::HTTP.new(uri.host, uri.port)
+      https.use_ssl = true
+
+      request = Net::HTTP::Post.new(uri.path)
+      request['Content-Type'] = 'application/json'
+      request.body = { text: text }.to_json
+
+      https.request(request)
+    end
+  end 
+end

--- a/config/initializers/slack.rb
+++ b/config/initializers/slack.rb
@@ -1,0 +1,1 @@
+SlackNotifier.slack_webhook_url = ENV['SLACK_WEBHOOK_URL']

--- a/config/initializers/time_slot_generation_worker.rb
+++ b/config/initializers/time_slot_generation_worker.rb
@@ -6,8 +6,7 @@ Thread.new do
   generation_service = TimeSlotGenerationService.new(create_slot: create_slot)
   
   worker = TimeSlotGenerationWorker.new(
-    time_slot_generation_service: generation_service,
-    slack_webhook_url: ENV['SLACK_WEBHOOK_URL']
+    time_slot_generation_service: generation_service
   )
 
   worker_options = TimeSlotGenerationWorker::Options.new(


### PR DESCRIPTION
Olá!

Esse PR extrai o código de notificações do Slack que estava dentro do `TimeSlotGenerationWorker` para um módulo próprio. Na sequência ele será utilizado para [notificações de anomalias nos dados](https://trello.com/c/wnXdJjqU/196-criar-mecanismo-de-monitoramento-das-garantias-do-sistema).

Também aproveitei pra fazer algumas pequenas melhorias no worker.

### Como testar

Crie uma variável de ambiente com o incoming webhook do canal: 

```sh
export SLACK_WEBHOOK_URL='https://hooks.slack.com/services/...'
```

Abra o console do Rails e utilize o `SlackNotifier` diretamente:

```ruby
SlackNotifier.info("Hello")
SlackNotifier.error("Omg")
SlackNotifier.success("All good")
```