### PR TITLE
Fix security issue on cancel action

### DIFF
--- a/app/controllers/time_slot_controller.rb
+++ b/app/controllers/time_slot_controller.rb
@@ -38,10 +38,13 @@ class TimeSlotController < PatientSessionController
   end
 
   def cancel
-    @appointment = Appointment.find(cancel_params[:appointment_id])
-    @appointment.update(patient_id: nil)
+    Appointment.transaction do
+      @current_patient.appointments
+        .where(id: cancel_params[:appointment_id])
+        .update_all(patient_id: nil)
 
-    @current_patient.update(last_appointment: nil)
+      @current_patient.update(last_appointment: nil)
+    end
 
     redirect_to time_slot_path
   end


### PR DESCRIPTION
Olá!

PR simples para corrigir uma brecha de segurança no cancelamento de agendamentos. A action estava aceitando qualquer ID de agendamento, sendo possível cancelar agendamentos de outros pacientes. 

Coloquei em uma transação também para evitar inconsistências de dados caso a atualização do agendamento falhe.