### PR TITLE
Extract schedule logic to service

### DIFF
--- a/app/controllers/time_slot_controller.rb
+++ b/app/controllers/time_slot_controller.rb
@@ -2,7 +2,6 @@ require_relative './../helpers/time_slot_helper'
 # include TimeSlotHelper
 
 class TimeSlotController < PatientSessionController
-
   before_action :render_patient_not_allowed
 
   SLOTS_WINDOW_IN_DAYS = 3
@@ -11,33 +10,33 @@ class TimeSlotController < PatientSessionController
     @ubs = Ubs.find(schedule_params[:ubs_id])
     start_time = Time.parse(schedule_params[:start_time])
 
-    @patient = Patient.find(current_patient.id)
-    return render 'patients/not_allowed' unless @patient.can_schedule?
+    result, data = appointment_scheduler.schedule(
+      raw_start_time: schedule_params[:start_time],
+      ubs: @ubs,
+      patient: current_patient
+    )
 
-    Appointment.transaction do
-      unless Appointment.where(start: start_time, ubs: @ubs, patient_id: nil).exists?
-        flash[:alert] = 'Opa! O horário foi reservado enquanto você escolhia, tente outro!'
-        redirect_to time_slot_path
-
-        return
-      end
-
-      Appointment.where(patient_id: current_patient.id).futures.each do |appointment|
-        appointment.update(patient_id: nil)
-      end
-
-      @appointment = Appointment.where(start: start_time, ubs: @ubs, patient_id: nil).first
-
-      return render json: @appointment.errors unless @appointment.update!(
-        patient_id: current_patient.id,
-        second_dose: current_patient.last_appointment&.second_dose,
-        vaccine_name: current_patient.last_appointment&.vaccine_name
+    case result
+    when :inactive_ubs
+      render_error_in_time_slots_page(
+        'Unidade de atendimento desativada. Tente novamente mais tarde.'
       )
+    when :schedule_conditions_unmet
+      render 'patients/not_allowed'
+    when :invalid_schedule_time
+      notify_invalid_schedule_attempt
+      render_error_in_time_slots_page('Data de agendamento inválida.')
+    when :all_slots_taken
+      render_error_in_time_slots_page(
+        'Opa! O horário foi reservado enquanto você escolhia, tente outro!'
+      )
+    when :success
+      @appointment = data
+      render 'patients/successfull_schedule'
+    else
+      notify_unexpected_result(result: result, data: data, context: context)
+      render_error_in_time_slots_page('Ocorreu um erro. Por favor, tente novamente.')
     end
-
-    @current_patient.update(last_appointment: @appointment)
-
-    render 'patients/successfull_schedule'
   end
 
   def cancel
@@ -74,8 +73,6 @@ class TimeSlotController < PatientSessionController
           appointments = Appointment.where(start: @current_day.at_beginning_of_day..@current_day.end_of_day, ubs: ubs, patient_id: nil)
         end
 
-        next unless appointments.exists?
-
         appointments.each do |appointment|
           slots << { slot_start: appointment.start, slot_end: appointment.end }
         end
@@ -86,6 +83,34 @@ class TimeSlotController < PatientSessionController
   end
 
   private
+
+  def render_error_in_time_slots_page(message)
+    flash[:alert] = message
+    redirect_to time_slot_path
+  end
+
+  def context
+    params.merge(patient_id: current_patient.id)
+  end
+
+  def notify_invalid_schedule_attempt
+    SlackNotifier.warn(
+      "Tentativa de agendamento fora da janela permitida.\n" \
+      "Contexto: `#{context.to_json}`"
+    )
+  end
+
+  def notify_unexpected_result(data)
+    SlackNotifier.warn(
+      "Agendamento com resultado inesperado! Dados: `#{data.to_json}`"
+    )
+  end
+
+  def appointment_scheduler
+    @appointment_scheduler ||= AppointmentScheduler.new(
+      max_schedule_time_ahead: SLOTS_WINDOW_IN_DAYS
+    )
+  end
 
   def render_patient_not_allowed
     return render 'patients/not_allowed' unless current_patient.can_schedule?

--- a/app/services/appointment_scheduler.rb
+++ b/app/services/appointment_scheduler.rb
@@ -1,0 +1,46 @@
+class AppointmentScheduler
+  def initialize(max_schedule_time_ahead:)
+    @max_schedule_time_ahead = if max_schedule_time_ahead.is_a?(ActiveSupport::Duration)
+      max_schedule_time_ahead
+    else
+      max_schedule_time_ahead.days
+    end
+  end
+
+  def schedule(raw_start_time:, ubs:, patient:)
+    start_time = Time.parse(raw_start_time)
+
+    return [:inactive_ubs] unless ubs.active?
+
+    Appointment.transaction do
+      patient.reload
+
+      return [:schedule_conditions_unmet] unless patient.can_schedule?
+      return [:invalid_schedule_time] if start_time > (Time.now.in_time_zone + @max_schedule_time_ahead).at_end_of_day
+
+      unless Appointment.where(start: start_time, ubs: ubs, patient_id: nil).exists?
+        return [:all_slots_taken]
+      end
+
+      Appointment.where(patient_id: patient.id).futures.each do |appointment|
+        appointment.update(patient_id: nil)
+      end
+
+      appointment = Appointment.where(start: start_time, ubs: ubs, patient_id: nil).first
+
+      appointment.update!(
+        patient_id: patient.id,
+        second_dose: patient.last_appointment&.second_dose,
+        vaccine_name: patient.last_appointment&.vaccine_name
+      )
+
+      patient.update!(last_appointment: appointment)
+
+      [:success, appointment]
+    end
+  rescue => e
+    Sentry.capture_exception(e)
+
+    [:internal_error, e.message]
+  end
+end

--- a/spec/services/appointment_scheduler_spec.rb
+++ b/spec/services/appointment_scheduler_spec.rb
@@ -1,0 +1,129 @@
+require 'rails_helper'
+
+RSpec.describe AppointmentScheduler, type: :service do
+  let(:max_schedule_time_ahead) { 3.days }
+  let(:scheduler) do
+    AppointmentScheduler.new(
+      max_schedule_time_ahead: max_schedule_time_ahead
+    )
+  end
+  # Eager UBS creation required because of patient.set_main_ubs
+  let!(:ubs) { create(:ubs, active: true) }
+  let(:patient) { create(:patient, cpf: '29468604004') }
+  let(:start_time) { '2020-01-01 12:40:00 -0300' }
+  let(:args) do
+    { raw_start_time: start_time, ubs: ubs, patient: patient }
+  end
+  let(:time) { Time.new('2020-01-01') }
+
+  before { travel_to time }
+  after { travel_back }
+
+  before do
+    allow(patient).to receive(:can_schedule?).and_return(true)
+  end
+
+  describe 'when ubs is inactive' do
+    before do
+      ubs.update!(active: false)
+    end
+
+    it 'returns an :inactive_ubs result' do
+      expect(scheduler.schedule(**args)).to eq([:inactive_ubs])
+    end
+
+    it 'does not update any appointment' do
+      expect { scheduler.schedule(**args) }
+        .not_to change { Appointment.all.map(&:attributes) }
+    end
+  end
+
+  describe 'when all slots were taken' do
+    before do
+      create_list(
+        :appointment,
+        3,
+        start: start_time,
+        ubs: ubs,
+        patient: create(:patient)
+      )
+    end
+
+    it 'does not update any appointment' do
+      expect { scheduler.schedule(**args) }
+        .not_to change { Appointment.all.map(&:attributes) }
+    end
+
+    it 'returns an :all_slots_taken result' do
+      expect(scheduler.schedule(**args)).to eq([:all_slots_taken])
+    end
+  end
+
+  describe 'when patient cannot schedule' do
+    before do
+      allow(patient).to receive(:can_schedule?).and_return(false)
+    end
+
+    it 'returns a :schedule_conditions_unmet result' do
+      expect(scheduler.schedule(**args)).to eq([:schedule_conditions_unmet])
+    end
+
+    it 'does not update any appointment' do
+      expect { scheduler.schedule(**args) }
+        .not_to change { Appointment.all.map(&:attributes) }
+    end
+  end
+
+  describe 'when start time is past allowed window' do
+    let(:start_time) { time + max_schedule_time_ahead + 1.day }
+    let(:schedule) do
+      scheduler.schedule(raw_start_time: start_time.to_s, patient: patient, ubs: ubs)
+    end
+
+    before do
+      create(:appointment, start: start_time, ubs: ubs, patient_id: nil)
+    end
+
+    it 'returns an :invalid_schedule_time result' do
+      expect(schedule).to eq([:invalid_schedule_time])
+    end
+
+    it 'does not update any appointment' do
+      expect { schedule }.not_to change { Appointment.all.map(&:attributes) }
+    end
+  end
+
+  describe 'when there are free time slots' do
+    before do
+      create_list(
+        :appointment,
+        3,
+        start: start_time,
+        ubs: ubs,
+        patient: nil
+      )
+    end
+
+    it 'updates exactly one appointment' do
+      expect(Appointment.count).to eq(3)
+      expect {
+        expect(scheduler.schedule(**args))
+          .to eq([:success, Appointment.find_by(patient_id: patient.id)])
+      }.to change { Appointment.where(patient_id: nil).count }.from(3).to(2)
+    end
+  end
+
+  describe 'when an exception is thrown' do
+    it 'returns an :internal_error result along with the error message' do
+      result, data = scheduler.schedule(raw_start_time: 'invalid', **args.except(:raw_start_time))
+
+      expect(result).to eq(:internal_error)
+      expect(data).to eq('no time information in "invalid"')
+    end
+  end
+
+  # TODO: implement when reschedule behavior is extracted
+  describe 'when patient already has a first dose appointment' do
+    it 'returns a :first_dose_already_scheduled'
+  end
+end


### PR DESCRIPTION
Olá.

Esse PR move o código da action `schedule` para um serviço, como parte do card [Melhorar a segurança e performance da action `schedule`](https://trello.com/c/ALVEXuuQ/200-melhorar-a-seguran%C3%A7a-e-performance-da-action-schedule).

Tentei deixar o código o mais próximo do que estava no controller e testá-lo assim, para em uma próxima etapa fazer as refatorações de performance. As questões de segurança e consistência de dados já foram feitas. Isso é:

* Segurança: 
  * Verificação de que a data/hora escolhida está dentro da janela permitida.
  * Verificação de que a UBS está ativa.
* Consistência: fazer todas as operações dentro da transação (`Patient.find` e `@current_patient.update` estavam fora na implementação anterior)

Também conversei com o @pedroCervi sobre extrairmos a lógica de reagendamento para outra action, porém considerando que as regras de negócio são muito semelhantes, precisamos pensar se vale a pena mesmo.