### PR TITLE
Allow previous appointment logic

### DIFF
--- a/app/controllers/patients/registrations_controller.rb
+++ b/app/controllers/patients/registrations_controller.rb
@@ -43,7 +43,7 @@ class Patients::RegistrationsController < Devise::RegistrationsController
 
     sign_in(patient, scope: :patient)
 
-    return render 'patients/not_allowed' unless patient.can_schedule?
+    return render 'patients/not_allowed' unless patient.can_see_appointment? || patient.can_schedule?
 
     return redirect_to index_bedridden_path if patient.bedridden?
 
@@ -73,7 +73,7 @@ class Patients::RegistrationsController < Devise::RegistrationsController
 
     if @patient.update_without_password(fields)
       flash[:notice] = 'Dados editados com sucesso!'
-      return render 'patients/not_allowed' unless @patient.can_schedule?
+      return render 'patients/not_allowed' unless @patient.can_see_appointment? || @patient.can_schedule?
 
       redirect_to index_time_slot_path
     else

--- a/app/controllers/patients/sessions_controller.rb
+++ b/app/controllers/patients/sessions_controller.rb
@@ -64,7 +64,7 @@ class Patients::SessionsController < Devise::SessionsController
 
     patient.update!(fake_mothers: [], login_attempts: 0)
 
-    return render 'patients/not_allowed' unless patient.can_schedule?
+    return render 'patients/not_allowed' unless patient.can_see_appointment? || patient.can_schedule?
 
     return redirect_to index_bedridden_path if patient.bedridden?
 

--- a/app/controllers/time_slot_controller.rb
+++ b/app/controllers/time_slot_controller.rb
@@ -52,7 +52,7 @@ class TimeSlotController < PatientSessionController
   end
 
   def index
-    @appointment = current_patient.current_appointment
+    @appointment = current_patient.appointments.order(:start).select(&:active?).last
     @ubs = @appointment.try(:ubs)
 
     @patient_can_schedule = current_patient.can_schedule?

--- a/app/controllers/time_slot_controller.rb
+++ b/app/controllers/time_slot_controller.rb
@@ -52,7 +52,7 @@ class TimeSlotController < PatientSessionController
   end
 
   def index
-    @appointment = current_patient.appointments.order(:start).select(&:active?).last
+    @appointment = current_patient.current_appointment
     @ubs = @appointment.try(:ubs)
 
     @patient_can_schedule = current_patient.can_schedule?

--- a/app/controllers/time_slot_controller.rb
+++ b/app/controllers/time_slot_controller.rb
@@ -55,6 +55,8 @@ class TimeSlotController < PatientSessionController
     @appointment = current_patient.current_appointment
     @ubs = @appointment.try(:ubs)
 
+    @patient_can_schedule = current_patient.can_schedule?
+
     @gap_in_days = slot_params[:gap_in_days].to_i || 0
     @current_day = Time.zone.now + @gap_in_days.days
 
@@ -115,7 +117,7 @@ class TimeSlotController < PatientSessionController
   end
 
   def render_patient_not_allowed
-    return render 'patients/not_allowed' unless current_patient.can_schedule?
+    return render 'patients/not_allowed' unless current_patient.can_see_appointment? || current_patient.can_schedule?
   end
 
   def slot_params

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -4,8 +4,8 @@ class Patient < ApplicationRecord
   MAX_LOGIN_ATTEMPTS = 2
 
   CONDITIONS = {
-    'População com 80 anos ou mais' => ->(patient) { patient.age >= 80 },
-    # 'Trabalhador(a) da Saúde que possua vínculo ativo em alguma unidade registrada no CNES' => ->(patient) { patient.in_group?('Trabalhador(a) da Saúde') },
+    'Trabalhador(a) da Saúde que possua vínculo ativo em alguma unidade registrada no CNES' => ->(patient) { patient.in_group?('Trabalhador(a) da Saúde') },
+    # 'População com 80 anos ou mais' => ->(patient) { patient.age >= 80 },
     # 'Paciente de teste' => ->(patient) { patient.cpf == ENV['ROOT_PATIENT_CPF'] },
     # 'Maiores de 60 anos institucionalizadas' => ->(patient) { patient.age >= 60 && patient.in_group?('Institucionalizado(a)') },
     # 'População Indígena' => ->(patient) { patient.in_group?('Indígena') },
@@ -32,20 +32,16 @@ class Patient < ApplicationRecord
   # TODO: remove `chronic` field from schema
   enum target_audience: [:kid, :elderly, :chronic, :disabled, :pregnant, :postpartum, :teacher, :over_55, :without_target]
 
-  def active_appointments
-    appointments.select(&:active?)
+  def current_appointment
+    appointments.order(:start).select(&:active?).last
   end
 
-  def current_appointment
-    active_appointments.last
+  def first_appointment
+    appointments.where.not(check_out: nil).order(:start).first
   end
 
   def can_see_appointment?
     return true if has_future_appointments?
-  end
-
-  def first_appointment
-    active_appointments.first
   end
 
   def can_schedule?

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -41,9 +41,17 @@ class Patient < ApplicationRecord
   end
 
   def can_schedule?
+    return true if future_appointments_present?
+
     CONDITIONS.values.any? do |condition|
       condition.call(self)
     end
+  end
+
+  def future_appointments_present?
+    appointments.where(
+      'start >= ? AND active = ?', Time.zone.now, true
+    ).present?
   end
 
   def in_group?(name)

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -40,9 +40,11 @@ class Patient < ApplicationRecord
     active_appointments.last
   end
 
-  def can_schedule?
+  def can_see_appointment?
     return true if has_future_appointments?
+  end
 
+  def can_schedule?
     CONDITIONS.values.any? do |condition|
       condition.call(self)
     end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -48,10 +48,10 @@ class Patient < ApplicationRecord
     end
   end
 
-  def future_appointments_present?
-    appointments.where(
-      'start >= ? AND active = ?', Time.zone.now, true
-    ).present?
+  def has_future_appointments?
+    appointments
+      .where('start >= ? AND active = TRUE', Time.zone.now)
+      .exists?
   end
 
   def in_group?(name)

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -41,7 +41,7 @@ class Patient < ApplicationRecord
   end
 
   def can_schedule?
-    return true if future_appointments_present?
+    return true if has_future_appointments?
 
     CONDITIONS.values.any? do |condition|
       condition.call(self)

--- a/app/services/appointment_scheduler.rb
+++ b/app/services/appointment_scheduler.rb
@@ -30,8 +30,8 @@ class AppointmentScheduler
 
       appointment.update!(
         patient_id: patient.id,
-        second_dose: patient.last_appointment&.second_dose,
-        vaccine_name: patient.last_appointment&.vaccine_name
+        second_dose: patient.appointments.order(:start).select(&:active?).last&.check_out.present?,
+        vaccine_name: patient.appointments.order(:start).select(&:active?).last&.vaccine_name
       )
 
       patient.update!(last_appointment: appointment)

--- a/app/services/appointment_scheduler.rb
+++ b/app/services/appointment_scheduler.rb
@@ -30,8 +30,8 @@ class AppointmentScheduler
 
       appointment.update!(
         patient_id: patient.id,
-        second_dose: patient.appointments.order(:start).select(&:active?).last&.check_out.present?,
-        vaccine_name: patient.appointments.order(:start).select(&:active?).last&.vaccine_name
+        second_dose: patient.current_appointment&.check_out.present?,
+        vaccine_name: patient.current_appointment&.vaccine_name
       )
 
       patient.update!(last_appointment: appointment)

--- a/app/views/patients/not_allowed.html.erb
+++ b/app/views/patients/not_allowed.html.erb
@@ -4,7 +4,7 @@
       <strong style="color: green;">CADASTRO CONCLUÍDO COM SUCESSO.</strong>
     </h2>
     <br/>
-    <p>
+    <p data-cy="patientNotAllowedText">
       Seu cadastro já foi concluído com sucesso, mas o agendamento para o seu grupo ainda não está disponível. Aguarde a divulgação das datas para agendamento.
     </p>
     <br/>

--- a/app/views/time_slot/index.html.erb
+++ b/app/views/time_slot/index.html.erb
@@ -114,23 +114,22 @@
     </div>
   <% end %>
 
-  <nav aria-label="Page navigation example">
-    <ul class="pagination justify-content-center">
-      <li class="page-item active <%= "disabled" if @gap_in_days < 1 %>">
-        <a class="page-link" href="?gap_in_days=<%= @gap_in_days - 1 %>" tabindex="-1">&laquo; Dia anterior</a>
-      </li>
-      <li class="page-item active disabled">
-        <a class="page-link" href="#">
-          <%= ApplicationHelper.humanize_date(@current_day) %>
-        </a>
-      </li>
-      <li class="page-item active <%= "disabled" if @gap_in_days >= TimeSlotController::SLOTS_WINDOW_IN_DAYS %>">
-        <a class="page-link" href="?gap_in_days=<%= @gap_in_days + 1 %>" tabindex="-1">Próximo dia &raquo;</a>
-      </li>
-    </ul>
-  </nav>
-
-  <% if @time_slots.present? %>
+  <% if @time_slots.present? && @patient_can_schedule %>
+    <nav aria-label="Page navigation example">
+      <ul class="pagination justify-content-center">
+        <li class="page-item active <%= "disabled" if @gap_in_days < 1 %>">
+          <a class="page-link" href="?gap_in_days=<%= @gap_in_days - 1 %>" tabindex="-1">&laquo; Dia anterior</a>
+        </li>
+        <li class="page-item active disabled">
+          <a class="page-link" href="#">
+            <%= ApplicationHelper.humanize_date(@current_day) %>
+          </a>
+        </li>
+        <li class="page-item active <%= "disabled" if @gap_in_days >= TimeSlotController::SLOTS_WINDOW_IN_DAYS %>">
+          <a class="page-link" href="?gap_in_days=<%= @gap_in_days + 1 %>" tabindex="-1">Próximo dia &raquo;</a>
+        </li>
+      </ul>
+    </nav>
     <div class="container mt-5">
       <div class="row">
         <div class="col">
@@ -188,12 +187,11 @@
       </div>
     </div>
   <% else %>
-    <h4>Nenhuma vaga disponível para este dia!</h4>
+    <h4>Nenhuma vaga disponível no momento!</h4>
     <div class="alert alert-info alert-dismissable" role="alert">
       <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
       <h6 class="mb-0">
-        Prezado usuário, no momento todas as vagas deste dia estão ocupadas.<br/>
-        Tente acessar os próximos dias para verificar se há agendamento disponível.<br/>
+        Prezado usuário, no momento todas as vagas estão ocupadas ou você não está entre o grupo que pode fazer um novo agendamento.<br/>
       </h6>
     </div>
   <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -176,7 +176,7 @@ end_of_day_minutes = [600, 620, 640, 660, 680, 700]
     ubs: ubs
   )
 
-  patient.update(last_appointment: second_appointment)
+  patient.update!(last_appointment: second_appointment)
 end
 
 ## TIME SLOTS / APPOINTMENTS ##

--- a/spec/cypress/app_commands/scenarios/second_dose_patient.rb
+++ b/spec/cypress/app_commands/scenarios/second_dose_patient.rb
@@ -23,8 +23,8 @@ Appointment.create(
 )
 
 second_appointment = Appointment.create(
-  start: Time.zone.today + 9.hours,
-  end: Time.zone.today + 9.hours + 15.minutes,
+  start: Time.zone.today.end_of_day - 15.minutes,
+  end: Time.zone.today.end_of_day,
   patient_id: patient.id,
   second_dose: true,
   vaccine_name: 'coronavac',

--- a/spec/cypress/app_commands/scenarios/young_marvin_son_of_tristeza.rb
+++ b/spec/cypress/app_commands/scenarios/young_marvin_son_of_tristeza.rb
@@ -1,0 +1,2 @@
+patient = Patient.find_by(cpf: command_options['cpf'])
+patient.update!(birth_date: '2000-01-31')

--- a/spec/cypress/integration/patient/appointment.js
+++ b/spec/cypress/integration/patient/appointment.js
@@ -33,9 +33,9 @@ describe('patient appointment flow', () => {
 
     context('when patient became not allowed', () => {
       beforeEach(() => {
-        cy.get('[data-cy=editPatientButton]').click()
-        cy.get('#patient_birth_date_1i').select('2000')
-        cy.get('[data-cy=updatePatientButton]').click()
+        cy.appScenario('young_marvin_son_of_tristeza', { cpf: cpf });
+
+        cy.visit('/')
       })
 
       it('replace appointment', () => {
@@ -62,9 +62,9 @@ describe('patient appointment flow', () => {
 
     context('when patient is not allowed', () => {
       beforeEach(() => {
-        cy.get('[data-cy=editPatientButton]').click()
-        cy.get('#patient_birth_date_1i').select('2000')
-        cy.get('[data-cy=updatePatientButton]').click()
+        cy.appScenario('young_marvin_son_of_tristeza', { cpf: cpf });
+
+        cy.visit('/')
       })
 
       it('renders not allowed', () => {
@@ -90,9 +90,9 @@ describe('patient appointment flow', () => {
 
     context('when patient became not allowed', () => {
       beforeEach(() => {
-        cy.get('[data-cy=editPatientButton]').click()
-        cy.get('#patient_birth_date_1i').select('2000')
-        cy.get('[data-cy=updatePatientButton]').click()
+        cy.appScenario('young_marvin_son_of_tristeza', { cpf: cpf });
+
+        cy.visit('/')
       })
 
       it('renders not allowed', () => {

--- a/spec/cypress/integration/patient/appointment.js
+++ b/spec/cypress/integration/patient/appointment.js
@@ -38,12 +38,6 @@ describe('patient appointment flow', () => {
         cy.visit('/')
       })
 
-      it('replace appointment', () => {
-        cy.createOrReplaceAppointment()
-
-        cy.get('[data-cy=currentAppointmentText]').should('exist')
-      })
-
       it('cancel appointment and renders not allowed', () => {
         cy.get('[data-cy=cancelAppointmentButton]').click()
         cy.get('[data-cy=patientNotAllowedText]').should('exist')

--- a/spec/cypress/integration/patient/appointment.js
+++ b/spec/cypress/integration/patient/appointment.js
@@ -50,19 +50,6 @@ describe('patient appointment flow', () => {
         cy.get('[data-cy=cancelAppointmentButton]').click()
         cy.get('[data-cy=noAppointmentYetText]').should('exist')
       })
-
-      context('when patient became not allowed', () => {
-        beforeEach(() => {
-          cy.appScenario('young_marvin_son_of_tristeza', { cpf: cpf });
-
-          cy.visit('/')
-        })
-
-        it('cancel appointment and renders not allowed', () => {
-          cy.get('[data-cy=cancelAppointmentButton]').click()
-          cy.get('[data-cy=patientNotAllowedText]').should('exist')
-        })
-      })
     })
 
     context('when has no future appointment scheduled', () => {
@@ -71,18 +58,6 @@ describe('patient appointment flow', () => {
           cy.createOrReplaceAppointment()
 
           cy.get('[data-cy=currentAppointmentText]').should('exist')
-        })
-      })
-
-      context('when patient is not allowed', () => {
-        beforeEach(() => {
-          cy.appScenario('young_marvin_son_of_tristeza', { cpf: cpf });
-
-          cy.visit('/')
-        })
-
-        it('renders not allowed', () => {
-          cy.get('[data-cy=patientNotAllowedText]').should('exist')
         })
       })
     })
@@ -100,18 +75,6 @@ describe('patient appointment flow', () => {
         cy.createOrReplaceAppointment()
 
         cy.get('[data-cy=currentAppointmentText]').should('exist')
-      })
-
-      context('when patient became not allowed', () => {
-        beforeEach(() => {
-          cy.appScenario('young_marvin_son_of_tristeza', { cpf: cpf });
-
-          cy.visit('/')
-        })
-
-        it('renders not allowed', () => {
-          cy.get('[data-cy=patientNotAllowedText]').should('exist')
-        })
       })
     })
   })

--- a/spec/cypress/integration/patient/appointment.js
+++ b/spec/cypress/integration/patient/appointment.js
@@ -73,6 +73,14 @@ describe('patient appointment flow', () => {
     })
   })
 
+  context('when has no future appointment scheduled', () => {
+    it('create appointment', () => {
+      cy.createOrReplaceAppointment()
+
+      cy.get('[data-cy=currentAppointmentText]').should('exist')
+    })
+  })
+
   context('when patient not attended yesterday', () => {
     beforeEach(() => {
       cy.appScenario('appointment_no_attended_yesterday', { cpf: cpf });

--- a/spec/cypress/integration/patient/appointment.js
+++ b/spec/cypress/integration/patient/appointment.js
@@ -73,14 +73,6 @@ describe('patient appointment flow', () => {
     })
   })
 
-  context('when has no future appointment scheduled', () => {
-    it('create appointment', () => {
-      cy.createOrReplaceAppointment()
-
-      cy.get('[data-cy=currentAppointmentText]').should('exist')
-    })
-  })
-
   context('when patient not attended yesterday', () => {
     beforeEach(() => {
       cy.appScenario('appointment_no_attended_yesterday', { cpf: cpf });

--- a/spec/cypress/integration/patient/appointment.js
+++ b/spec/cypress/integration/patient/appointment.js
@@ -30,13 +30,46 @@ describe('patient appointment flow', () => {
       cy.get('[data-cy=cancelAppointmentButton]').click()
       cy.get('[data-cy=noAppointmentYetText]').should('exist')
     })
+
+    context('when patient became not allowed', () => {
+      beforeEach(() => {
+        cy.get('[data-cy=editPatientButton]').click()
+        cy.get('#patient_birth_date_1i').select('2000')
+        cy.get('[data-cy=updatePatientButton]').click()
+      })
+
+      it('replace appointment', () => {
+        cy.createOrReplaceAppointment()
+
+        cy.get('[data-cy=currentAppointmentText]').should('exist')
+      })
+
+      it('cancel appointment and renders not allowed', () => {
+        cy.get('[data-cy=cancelAppointmentButton]').click()
+        cy.get('[data-cy=patientNotAllowedText]').should('exist')
+      })
+    })
   })
 
   context('when has no future appointment scheduled', () => {
-    it('create appointment', () => {
-      cy.createOrReplaceAppointment()
+    context('when patient is allowed', () => {
+      it('create appointment', () => {
+        cy.createOrReplaceAppointment()
 
-      cy.get('[data-cy=currentAppointmentText]').should('exist')
+        cy.get('[data-cy=currentAppointmentText]').should('exist')
+      })
+    })
+
+    context('when patient is not allowed', () => {
+      beforeEach(() => {
+        cy.get('[data-cy=editPatientButton]').click()
+        cy.get('#patient_birth_date_1i').select('2000')
+        cy.get('[data-cy=updatePatientButton]').click()
+      })
+
+      it('renders not allowed', () => {
+        cy.get('[data-cy=patientNotAllowedText]').should('exist')
+      })
     })
   })
 
@@ -47,6 +80,24 @@ describe('patient appointment flow', () => {
 
     it('has no appointment scheduled', () => {
       cy.get('[data-cy=noAppointmentYetText]').should('exist')
+    })
+
+    it('create appointment', () => {
+      cy.createOrReplaceAppointment()
+
+      cy.get('[data-cy=currentAppointmentText]').should('exist')
+    })
+
+    context('when patient became not allowed', () => {
+      beforeEach(() => {
+        cy.get('[data-cy=editPatientButton]').click()
+        cy.get('#patient_birth_date_1i').select('2000')
+        cy.get('[data-cy=updatePatientButton]').click()
+      })
+
+      it('renders not allowed', () => {
+        cy.get('[data-cy=patientNotAllowedText]').should('exist')
+      })
     })
   })
 })

--- a/spec/cypress/integration/patient/appointment.js
+++ b/spec/cypress/integration/patient/appointment.js
@@ -5,6 +5,25 @@ describe('patient appointment flow', () => {
     cy.visit('/')
   })
 
+  context('when patient is a second dose patient', () => {
+    beforeEach(() => {
+      cy.appScenario('second_dose_patient', { cpf: cpf });
+      
+      cy.visit('/')
+      
+      cy.loginAsPatient(cpf)
+    })
+    
+    it('can cancel and reeschedule same vaccine', () => {
+      cy.get('[data-cy=appliedVaccineName]').should('contain', 'Coronavac')
+
+      cy.get('[data-cy=cancelAppointmentButton]').click()
+      cy.createOrReplaceAppointment()
+
+      cy.get('[data-cy=appliedVaccineName]').should('contain', 'Coronavac')
+    })
+  })
+
   context('when patient is not already vaccineted', () => {
     beforeEach(() => {
       cy.visit('/')

--- a/spec/cypress/support/commands.js
+++ b/spec/cypress/support/commands.js
@@ -22,7 +22,7 @@ Cypress.Commands.add('signupPatient', (cpf) => {
 
 Cypress.Commands.add('createOrReplaceAppointment', () => {
   cy.get('[data-cy=ubsTimeSlots]').click()
-  cy.get('.btn-success').last().click()
+  cy.get('.btn-success').first().click()
   cy.get('[data-cy=backButton]').click()
 })
 


### PR DESCRIPTION

Pessoal, pensei aqui na seguinte lógica:

A regra de permitir agendamento não é cumulativa, logo, quando ela muda, pacientes com agendamento em haver mas que sairam da regra deixam de poder ver/cancelar ou se reagendar. Fiz uma modificação no `can_schedule?`. Ou seja, todos que ja tem agendamento no futuro ou que entram nas condições de agendamento podem ver/substituir/cancelar.

O unico porem é, se cancelar o sujeito perde a capacidade de pegar de volta porque ele fica com seus agendamentos futuros nulos. Me parece ok.

MEU DEUS COMO É BOM PODER TESTAR ISSO!!!!

huiahuiahui 

bom domingo.

### Rodando cypress na máquina local sem docker
```
rvm use 2.6.5
bundle install
rails s -e test
```
e em outro terminal:
```
rails db:create
RAILS_ENV=test rails db:migrate
npx cypress open --project ./spec
```
note que você vai precisar de um postgres rodando localmente e seu `database.yml` precisa apontar corretamente para ele.