### PR TITLE
Optimize AppointmentScheduler queries

### DIFF
--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -10,7 +10,13 @@ class Appointment < ApplicationRecord
     where('start >= ? AND appointments.end <= ?', day.beginning_of_day, day.end_of_day)
   end
 
-  scope :futures, -> { where('start > ?', Time.current) }
+  scope :futures, -> { where('start > ?', Time.zone.now) }
+
+  scope :free, -> { joins(:ubs).where(ubs: { active: true }).where(patient_id: nil) }
+
+  scope :within_allowed_window, -> {
+    where(start: Time.zone.now..(Time.zone.now + SLOTS_WINDOW_IN_DAYS.days).end_of_day)
+  }
 
   def active?
     active == true
@@ -18,13 +24,5 @@ class Appointment < ApplicationRecord
 
   def in_allowed_check_in_window?
     start > Time.zone.now.beginning_of_day && start < Time.zone.now.end_of_day
-  end
-
-  def self.free
-    joins(:ubs).where(ubs: { active: true }).where(patient_id: nil)
-  end
-
-  def self.within_allowed_window
-    where(start: Time.zone.now..(Time.zone.now + SLOTS_WINDOW_IN_DAYS.days).end_of_day)
   end
 end

--- a/db/migrate/20210301015841_add_indices_to_appointments.rb
+++ b/db/migrate/20210301015841_add_indices_to_appointments.rb
@@ -1,0 +1,6 @@
+class AddIndicesToAppointments < ActiveRecord::Migration[6.0]
+  def change
+    add_index :appointments, :start
+    add_index :appointments, :patient_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_14_133154) do
+ActiveRecord::Schema.define(version: 2021_03_01_015841) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,8 @@ ActiveRecord::Schema.define(version: 2021_02_14_133154) do
     t.boolean "second_dose", default: false
     t.string "suspend_reason"
     t.string "vaccine_name"
+    t.index ["patient_id"], name: "index_appointments_on_patient_id"
+    t.index ["start"], name: "index_appointments_on_start"
     t.index ["ubs_id"], name: "index_appointments_on_ubs_id"
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,6 +41,14 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
+  config.around(:each, use_transactional_tests: false) do |example|
+    self.use_transactional_tests = false
+    example.run
+    self.use_transactional_tests = true
+
+    DatabaseCleaner.clean_with(:deletion)
+  end
+
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.


### PR DESCRIPTION
Olá!

Esse PR refatora o código do `AppointmentScheduler` para evitar inconsistências e melhorar o desempenho da transação.

 A lógica que verifica se a data/hora é válida estava dentro da transação desnecessariamente, então foi movida para fora, evitando o `patient.reload`.

Na transação, o isolation level foi trocado para [repeatable read](https://dev.to/techschoolguru/understand-isolation-levels-read-phenomena-in-mysql-postgres-c2e#repeatable-read-isolation-level-in-postgres) para evitar que duas transações vejam o mesmo `Appointment` com `patient_id` vazio e uma sobrescreva o `patient_id` da outra. Isso deve resolver mais algumas inconsistências que estávamos tendo. 
Além disso, o código de atualização dos agendamentos futuros do paciente foi refatorado para utilizar uma única query.

Também foram adicionados índices para colunas da tabela `appointments` que são consultadas frequentemente.