### PR TITLE
Fix to show the correct current_appointment

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -32,12 +32,8 @@ class Patient < ApplicationRecord
   # TODO: remove `chronic` field from schema
   enum target_audience: [:kid, :elderly, :chronic, :disabled, :pregnant, :postpartum, :teacher, :over_55, :without_target]
 
-  def active_appointments
-    appointments.select(&:active?)
-  end
-
   def current_appointment
-    active_appointments.last
+    appointments.order(:start).select(&:active?).last
   end
 
   def can_schedule?

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -37,7 +37,7 @@ class Patient < ApplicationRecord
   end
 
   def first_appointment
-    active_appointments.first
+    appointments.where.not(check_out: nil).order(:start).first
   end
 
   def can_schedule?


### PR DESCRIPTION
Olá!

Neste Pull Request foi realizado uma correção para que seja exibido na view `time_slot/index.html` corretamente o último agendamento futuro ativo que o paciente realizou.

Até o momento o sistema não garante que será escolhido o último agendamento ativo.

Para verificar a mudança, execute os comandos abaixo via console:

```ruby
patient = Patient.new(
  name: 'marvin',
  cpf: '83274229792',
  mother_name: 'Tristeza',
  birth_date: '1900-01-31',
  public_place: 'Rua',
  place_number: '200',
  neighborhood: 'Glória',
  phone: '(47) 91234-5678'
)
patient.groups << Group.find_by(name: 'Trabalhador(a) da Saúde')
patient.save!

ubs = Ubs.find_by!(active: true)

time_first_dose = (Time.zone.now - 1.days)
time_second_dose = Time.zone.now.end_of_day

appointment1 = Appointment.create!(
  start: time_second_dose,
  end: time_second_dose,
  patient_id: patient.id,
  second_dose: true,
  active: true,
  ubs: ubs,
  check_in: nil,
  check_out: nil,
  vaccine_name: 'coronavac'
)

appointment2 = Appointment.create!(
  start: time_first_dose,
  end: time_first_dose + 15.minutes,
  patient_id: patient.id,
  second_dose: false,
  active: true,
  ubs: ubs,
  check_in: time_first_dose + 1.hours,
  check_out: (time_first_dose + 1.hours) + 15.minutes,
  vaccine_name: 'coronavac'
)

patient.update!(last_appointment: appointment2)
```

E depois entre no sistema como paciente com este CPF **83274229792** e é possível verificar que o card aparece, se retirar a alteração, o mesmo some.


Obs.: Não fiz criei um teste no cypress para testar esta condição pois estranhamente no cypress não estava aparecendo o card do mesmo jeito, mesmo fazendo o mesmo passo a passo manualmente e verificando que apresentou o comportamento esperado.