### PR TITLE
Silly refactor on seeds, just to make it more readable

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,55 +6,60 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-user = User.new
-user.name = 'mlabs'
-user.password = 'dontpanic'
-user.password_confirmation = 'dontpanic'
-user.save!
+mlabs = User.new.tap do |user|
+  user.name = 'mlabs'
+  user.password = 'dontpanic'
+  user.password_confirmation = 'dontpanic'
+  user.save!
+end
 
-other_user = User.new
-other_user.name = 'mlabs_two'
-other_user.password = 'dontpanic'
-other_user.password_confirmation = 'dontpanic'
-other_user.save!
+mlabs_two = User.new.tap do |user|
+  user.name = 'mlabs_two'
+  user.password = 'dontpanic'
+  user.password_confirmation = 'dontpanic'
+  user.save!
+end
 
-neighborhood = Neighborhood.new
-neighborhood.name = 'América'
-neighborhood.save!
+america = Neighborhood.new.tap do |neighborhood|
+  neighborhood.name = 'América'
+  neighborhood.save!
+end
 
-other_neighborhood = Neighborhood.new
-other_neighborhood.name = 'Glória'
-other_neighborhood.save!
+gloria = Neighborhood.new.tap do |neighborhood|
+  neighborhood.name = 'Glória'
+  neighborhood.save!
+end
 
-ubs = Ubs.new
-ubs.name = 'UBSF America'
-ubs.user = user
-ubs.neighborhoods << neighborhood
-ubs.neighborhood = neighborhood
-ubs.address = 'Rua Magrathea, 42'
-ubs.phone = '(47) 3443-3443'
-ubs.shift_start = '9:00'
-ubs.break_start = '12:30'
-ubs.break_end = '13:30'
-ubs.shift_end = '17:00'
-ubs.slot_interval_minutes = 20
-ubs.active = true
-ubs.valid?
-ubs.save!
+ubsf_america = Ubs.new.tap do |ubs|
+  ubs.name = 'UBSF America'
+  ubs.user = mlabs
+  ubs.neighborhoods << america
+  ubs.neighborhood = america
+  ubs.address = 'Rua Magrathea, 42'
+  ubs.phone = '(47) 3443-3443'
+  ubs.shift_start = '9:00'
+  ubs.break_start = '12:30'
+  ubs.break_end = '13:30'
+  ubs.shift_end = '17:00'
+  ubs.slot_interval_minutes = 20
+  ubs.active = true
+  ubs.save!
+end
 
-other_ubs = Ubs.new
-other_ubs.name = 'UBSF Gloria'
-other_ubs.user = other_user
-other_ubs.neighborhood = other_neighborhood
-other_ubs.neighborhoods << other_neighborhood
-other_ubs.address = 'Rua dos Bobos, 0'
-other_ubs.phone = '(47) 3443-3455'
-other_ubs.shift_start = '9:00'
-other_ubs.break_start = '12:30'
-other_ubs.break_end = '13:30'
-other_ubs.shift_end = '17:00'
-other_ubs.slot_interval_minutes = 15
-other_ubs.save!
+Ubs.new.tap do |ubs|
+  ubs.name = 'UBSF Gloria'
+  ubs.user = mlabs_two
+  ubs.neighborhood = gloria
+  ubs.neighborhoods << gloria
+  ubs.address = 'Rua dos Bobos, 0'
+  ubs.phone = '(47) 3443-3455'
+  ubs.shift_start = '9:00'
+  ubs.break_start = '12:30'
+  ubs.break_end = '13:30'
+  ubs.shift_end = '17:00'
+  ubs.slot_interval_minutes = 15
+  ubs.save!
+end
 
 [
   'Trabalhador(a) da Saúde',
@@ -72,7 +77,7 @@ other_ubs.save!
   'Pessoa com deficiência permanente grave',
   'Não me encaixo em nenhum dos grupos listados',
 ].each do |name|
-  Group.create(name: name)
+  Group.create!(name: name)
 end
 
 [
@@ -88,7 +93,7 @@ end
   'Síndrome de down',
   'Outra(s)',
 ].each do |subgroup|
-  Group.create(name: subgroup, parent_group_id: Group.find_by(name: 'Portador(a) de comorbidade').id)
+  Group.create!(name: subgroup, parent_group_id: Group.find_by!(name: 'Portador(a) de comorbidade').id)
 end
 
 [
@@ -97,37 +102,24 @@ end
   'Estagiário da área da Saúde',
   'Atua em Hospital',
 ].each do |subgroup|
-  Group.create(name: subgroup, parent_group_id: Group.find_by(name: 'Trabalhador(a) da Saúde').id)
+  Group.create!(name: subgroup, parent_group_id: Group.find_by!(name: 'Trabalhador(a) da Saúde').id)
 end
 
 [
   'Professor(a) em sala de aula',
   'Administrativo e outros setores',
 ].each do |subgroup|
-  Group.create(name: subgroup, parent_group_id: Group.find_by(name: 'Trabalhador(a) da Educação').id)
+  Group.create!(name: subgroup, parent_group_id: Group.find_by!(name: 'Trabalhador(a) da Educação').id)
 end
 
 [
   'Oficial em atividade de linha de frente',
   'Oficial em atividade administrativa',
 ].each do |subgroup|
-  Group.create(name: subgroup, parent_group_id: Group.find_by(name: 'Trabalhador(a) das Forças de Seguranças e Salvamento').id)
+  Group.create!(name: subgroup, parent_group_id: Group.find_by!(name: 'Trabalhador(a) das Forças de Seguranças e Salvamento').id)
 end
 
 ## SECOND DOSE PATIENTS ##
-
-second_dose_cpfs = %w[
-  65622137543
-  41759484733
-  88949973677
-  53847313118
-  00455327106
-  57984523606
-  94831933201
-  59711354063
-  56105631430
-  25532025126
-]
 
 current_time = Time.now.in_time_zone
 begin_date = 0.days.from_now.to_date.in_time_zone
@@ -141,20 +133,32 @@ second_appointment_end = today + 8.hours
 
 end_of_day_minutes = [600, 620, 640, 660, 680, 700]
 
-10.times do |i|
-  patient = Patient.new
-  patient.name = "marvin#{i}"
-  patient.cpf = second_dose_cpfs[i]
-  patient.mother_name = 'Tristeza'
-  patient.birth_date = '1920-01-31'
-  patient.phone = '(47) 91234-5678'
-  patient.neighborhood = 'América'
-  patient.groups << Group.find_by(name: 'Trabalhador(a) da Saúde')
-  patient.save!
+%w[
+  65622137543
+  41759484733
+  88949973677
+  53847313118
+  00455327106
+  57984523606
+  94831933201
+  59711354063
+  56105631430
+  25532025126
+].each_with_index do |cpf, i|
+  patient = Patient.new.tap do |patient|
+    patient.name = "marvin#{i}"
+    patient.cpf = cpf
+    patient.mother_name = 'Tristeza'
+    patient.birth_date = '1920-01-31'
+    patient.phone = '(47) 91234-5678'
+    patient.neighborhood = 'América'
+    patient.groups << Group.find_by(name: 'Trabalhador(a) da Saúde')
+    patient.save!
+  end
 
   time_multiplier = end_of_day_minutes.sample.minutes
 
-  Appointment.create(
+  Appointment.create!(
     start: second_appointment_start - 4.weeks + time_multiplier,
     end: second_appointment_end - 4.weeks + time_multiplier,
     patient_id: patient.id,
@@ -163,17 +167,17 @@ end_of_day_minutes = [600, 620, 640, 660, 680, 700]
     vaccine_name: 'coronavac',
     check_in: second_appointment_start - 4.weeks + time_multiplier,
     check_out: second_appointment_start - 4.weeks + 10.minutes + time_multiplier,
-    ubs: ubs
+    ubs: ubsf_america
   )
 
-  second_appointment = Appointment.create(
+  second_appointment = Appointment.create!(
     start: second_appointment_start + time_multiplier,
     end: second_appointment_end + time_multiplier,
     patient_id: patient.id,
     second_dose: true,
     vaccine_name: 'coronavac',
     active: true,
-    ubs: ubs
+    ubs: ubsf_america
   )
 
   patient.update!(last_appointment: second_appointment)
@@ -181,14 +185,15 @@ end
 
 ## TIME SLOTS / APPOINTMENTS ##
 
-config = ubs.create_time_slot_generation_config!(ubs_id: ubs.id)
-config[:windows] = [
-  { start_time: '07:40', end_time: '08:00', slots: 6 },
-  { start_time: '08:00', end_time: '16:20', slots: 8 },
-  { start_time: '16:20', end_time: '22:00', slots: 4 }
-]
-config[:max_appointment_time_ahead] = 0
-config.save!
+ubsf_america.create_time_slot_generation_config!(ubs_id: ubsf_america.id).tap do |config|
+  config[:windows] = [
+    { start_time: '07:40', end_time: '08:00', slots: 6 },
+    { start_time: '08:00', end_time: '16:20', slots: 8 },
+    { start_time: '16:20', end_time: '22:00', slots: 4 }
+  ]
+  config[:max_appointment_time_ahead] = 0
+  config.save!
+end
 
 create_slot = lambda do |attributes|
   Appointment.create!(attributes)
@@ -205,8 +210,8 @@ worker_opts = TimeSlotGenerationWorker::Options.new(
   execution_hour: current_time.hour
 )
 
-# mimic successfull worker.execute
-worker.generate_ubs_time_slots(ubs, worker_opts, current_time)
+# mimic successful worker.execute
+worker.generate_ubs_time_slots(ubsf_america, worker_opts, current_time)
 TimeSlotGeneratorExecution.where(date: current_time.to_date).update_all(status: 'done')
 
 ## FIRST DOSE PATIENTS ##
@@ -222,12 +227,10 @@ cpfs = %w[
   45963347149
   89452953136
   45445585654
-]
-
-10.times do |i|
+].each_with_index do |cpf, i|
   patient = Patient.new
   patient.name = "marvin#{i+10}"
-  patient.cpf = cpfs[i]
+  patient.cpf = cpf
   patient.mother_name = 'Tristeza'
   patient.birth_date = '1920-06-24'
   patient.phone = '(47) 91234-5678'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -152,7 +152,7 @@ end_of_day_minutes = [600, 620, 640, 660, 680, 700]
     patient.birth_date = '1920-01-31'
     patient.phone = '(47) 91234-5678'
     patient.neighborhood = 'América'
-    patient.groups << Group.find_by(name: 'Trabalhador(a) da Saúde')
+    patient.groups << Group.find_by!(name: 'Trabalhador(a) da Saúde')
     patient.save!
   end
 


### PR DESCRIPTION
Selflessly refactoring seeds as I prefer the use of `tap` as well as using `!`'s in order to raise exception instead of silently returning `false` if something can't get created.

Note for the future: Ideally, seeds should be idempotent and `rails db:seeds` should be run on all environments (including production), which would be ideal for neighborhoods. The existing one could be just moved to be run through `rails db:seeds:development` for instance.

No UI/UX changes, intended for developer audience only.