### PR TITLE
Bump Ruby version to 2.6.6

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,7 @@ AllCops:
     - 'Guardfile'
     - 'Dangerfile'
   NewCops: enable
-  TargetRubyVersion: 2.6.5
+  TargetRubyVersion: 2.6.6
 
 Documentation:
   Enabled: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.5
+FROM ruby:2.6.6
 
 RUN apt-get update -qq && apt-get install -y nodejs postgresql-client cmake npm
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ um sistema de agendamento de vacinação e exames de COVID-19 para a prefeitura 
 Este projeto usa o framework de desenvolvimento Web Ruby on Rails e possui as seguintes
 dependências:
 
-- Ruby >= 2.6.5
+- Ruby >= 2.6.6
 - Node >= 13.2.0
 - PostgreSQL == 12.1
 - Install Docker - [See Instalation](https://docs.docker.com/install/overview/)


### PR DESCRIPTION
Followup to commit 79428ba36b3a484852af6b43a7b27aa88ddb6c8c.

This should™ fix the following error when running `docker-compose up`:

```
Your Ruby version is 2.6.5, but your Gemfile specified 2.6.6
The command '/bin/sh -c bundle install --jobs 4' returned a non-zero code: 18
ERROR: Service 'web' failed to build
```