### PR TITLE
Set appointments.active as true by default

### DIFF
--- a/db/migrate/20210325161545_change_appointment_active_default_to_true.rb
+++ b/db/migrate/20210325161545_change_appointment_active_default_to_true.rb
@@ -1,0 +1,5 @@
+class ChangeAppointmentActiveDefaultToTrue < ActiveRecord::Migration[6.0]
+  def change
+    change_column :appointments, :active, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_01_015841) do
+ActiveRecord::Schema.define(version: 2021_03_25_161545) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2021_03_01_015841) do
   create_table "appointments", force: :cascade do |t|
     t.datetime "start"
     t.datetime "end"
-    t.boolean "active"
+    t.boolean "active", default: true, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "ubs_id"


### PR DESCRIPTION
Those are set as false by default right now, causing some issues when we forget to set it to on.