### PR TITLE
Refactor to allow multiple ubs

### DIFF
--- a/app/services/time_slot_generation_service.rb
+++ b/app/services/time_slot_generation_service.rb
@@ -100,7 +100,7 @@ class TimeSlotGenerationService
 
       next if appointment_end > date + window_range.end
 
-      taken_slots_count = Appointment.where(start: appointment_start).count
+      taken_slots_count = Appointment.where(start: appointment_start, ubs_id: options.ubs_id).count
       new_slots_count = window[:slots] - taken_slots_count
 
       report[appointment_start.to_s] = { taken_slots_count: taken_slots_count, new_slots_count: new_slots_count }

--- a/app/views/ubs/patient_checkout.html.erb
+++ b/app/views/ubs/patient_checkout.html.erb
@@ -15,7 +15,8 @@
     <a href="#" class="close" data-dismiss="alert" aria-label="close">&times;</a>
     <div class="row" style="font-size: 2rem;">
       <div class="col-8">
-        <b data-cy="secondDoseScheduledText">Agendamento Marcado</b> - 2ª dose da vacina:
+        <b data-cy="secondDoseScheduledText">Agendamento Marcado</b> - 2ª dose da vacina:<br/>
+        <b>Unidade:</b> <%= @second_dose_appointment.ubs.name %>
       </div>
       <div class="col-4" style="text-align: right">
         <b><%= @second_dose_appointment.start.strftime("%d/%m - %H:%M") %></b>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -59,6 +59,7 @@ Ubs.new.tap do |ubs|
   ubs.break_end = '13:30'
   ubs.shift_end = '17:00'
   ubs.slot_interval_minutes = 15
+  ubs.active = true
   ubs.save!
 end
 
@@ -196,6 +197,19 @@ TimeSlotGenerationService.new(create_slot: lambda { |attrs| Appointment.create(a
                              excluded_dates: [],
                              windows: [{ start_time: '7:00', end_time: '23:59', slots: 2 }],
                              slot_interval_minutes: 30
+                           )
+                         )
+
+TimeSlotGenerationService.new(create_slot: lambda { |attrs| Appointment.create(attrs) })
+                         .execute(
+                           TimeSlotGenerationService::Options.new(
+                             ubs_id: Ubs.second.id,
+                             start_date: 15.minutes.from_now.to_datetime,
+                             end_date: 4.days.from_now.to_datetime,
+                             weekdays: [*0..6],
+                             excluded_dates: [],
+                             windows: [{ start_time: '12:00', end_time: '19:00', slots: 2 }],
+                             slot_interval_minutes: 20
                            )
                          )
 


### PR DESCRIPTION
Olá!

Esse PR busca refatorar a lógica do sistema afim de permitir o funcionamento de várias `Ubs` ativas no sistema! :tada: 

### O que mudou:

* Incluído o filtro de `Ubs` na hora de buscar vagas já criadas no `TimeSlotGenerationService`;
* Incluído filtro para buscar somente agendamentos da unidade atual na busca do *Check-in* e *Check-out* do paciente nas telas do Operador (`User`);
* Informado a unidade da segunda dose agendada após confirmação do *Check-out*:
![Screenshot from 2021-03-29 11-49-44](https://user-images.githubusercontent.com/19494561/112859098-e3fea300-9088-11eb-876d-e5956790eeb8.png)
