### PR TITLE
test: when schedulling is disabled

### DIFF
--- a/app/controllers/community/appointments_controller.rb
+++ b/app/controllers/community/appointments_controller.rb
@@ -19,7 +19,7 @@ module Community
     def index
       if Rails.configuration.x.disabled_reschedule_toggle.present?
         return redirect_to(home_community_appointments_path,
-                           flash: { alert: I18n.t(:'alerts.patient_disabled_reschedule') })
+                           flash: { alert: I18n.t(:'alerts.patient_disabled_reschedule'), cy: 'appointmentSchedullingIsDisabledText' })
       end
 
       @appointment = current_patient.appointments.not_checked_in.current
@@ -28,6 +28,7 @@ module Community
       @appointments = scheduler.open_times_per_ubs(from: @days.days.from_now.beginning_of_day,
                                                    to: @days.days.from_now.end_of_day)
     rescue AppointmentScheduler::NoFreeSlotsAhead
+      # TODO: no test coverage for this scenario on cypress
       redirect_to home_community_appointments_path, flash: { alert: 'Não há vagas disponíveis para reagendamento.' }
     end
 

--- a/app/views/community/appointments/_home_has_appointment.html.erb
+++ b/app/views/community/appointments/_home_has_appointment.html.erb
@@ -68,7 +68,7 @@
         <% if Rails.configuration.x.disabled_reschedule_toggle.present? -%>
           <div class="row mt-4">
             <div class="col">
-              <div class="alert alert-warning">
+              <div class="alert alert-warning" data-cy="appointmentSchedullingIsDisabledText">
                 <%= I18n.t(:'alerts.patient_disabled_reschedule') %>
               </div>
             </div>

--- a/config/locales/views.pt-BR.yml
+++ b/config/locales/views.pt-BR.yml
@@ -33,6 +33,6 @@ pt-BR:
   alerts:
     patient_disabled_reschedule: >
       Devido a alta demanda, o reagendamento está temporariamente desativado. Se você não poder comparecer no horário,
-      dia e local estabelecidos, tente reagendar novamente mais tarde, ou cancele seu agendamento e tente agende
+      dia e local estabelecidos, tente reagendar novamente mais tarde, ou cancele seu agendamento e tente agendar
       novamente mais tarde ou quando mais doses forem disponibilizadas.
 

--- a/spec/cypress/app_commands/scenarios/schedulling_is_disabled.rb
+++ b/spec/cypress/app_commands/scenarios/schedulling_is_disabled.rb
@@ -1,0 +1,1 @@
+Rails.configuration.x.disabled_reschedule_toggle = 'true'

--- a/spec/cypress/app_commands/scenarios/schedulling_is_enabled.rb
+++ b/spec/cypress/app_commands/scenarios/schedulling_is_enabled.rb
@@ -1,0 +1,1 @@
+Rails.configuration.x.disabled_reschedule_toggle = ''

--- a/spec/cypress/integration/patient/appointment.js
+++ b/spec/cypress/integration/patient/appointment.js
@@ -1,6 +1,39 @@
 describe('patient appointment flow', () => {
   const cpf = '83274229792'
 
+  beforeEach(() => {
+    cy.appScenario('schedulling_is_enabled');
+  })
+
+  context('when schedulling is disabled', () => {
+    beforeEach(() => {
+      cy.appScenario('marvin_son_of_tristeza', { cpf: cpf });
+      cy.appScenario('schedulling_is_disabled');
+      cy.visit('/')
+      cy.loginAsPatient(cpf)
+    })
+  
+    context('when patient tries to create an appointment', () => {
+      it('shows disabled schedulling message and does not creates an appointment', () => {
+        cy.visit('/')
+        cy.get('[data-cy=appointmentRescheduleButton]').click()
+        cy.get('[data-cy=appointmentSchedullingIsDisabledText]').should('exist')
+        cy.get('[data-cy=scheduledAppointmentText]').should('not.exist')
+      })
+    })
+
+    context('when patient has appointment', () => {
+      beforeEach(() => {
+        cy.appScenario('appointment_today', { cpf: cpf });
+      })
+
+      it('shows disabled schedulling message', () => {
+        cy.visit('/')
+        cy.get('[data-cy=appointmentSchedullingIsDisabledText]').should('exist')
+      })
+    })
+  })
+
   context('when patient cannot schedule', () => {
     beforeEach(() => {
       cy.appScenario('marvin_son_of_tristeza', { cpf: cpf, birth_date: '2000-06-08' });
@@ -80,7 +113,7 @@ describe('patient appointment flow', () => {
 
       it('can see no appointments available text', () => {
         cy.get('[data-cy=noAppointmentsAvailableText]').should('exist')
-      })      
+      })
     })
   })
 


### PR DESCRIPTION
Oi galera!

Só aumentando um pouco a cobertura do cypress.

Fiquei na dúvida se essa configuração global desabilita o agendamento ou só o reagendamento. Tipo. Se ativada, onde ela está agora tenho a impressão que vai desabilitar agendamentos como um todo :thinking: deveria?

Caso não, seria só questão de mover o redirect para o scheduler ou algo do tipo.