### PR TITLE
Cobertura de testes: casos de borda

### DIFF
--- a/app/controllers/community/appointments_controller.rb
+++ b/app/controllers/community/appointments_controller.rb
@@ -22,7 +22,11 @@ module Community
       if @appointment && !@appointment.can_cancel_and_reschedule?
         return redirect_to(
           home_community_appointments_path,
-          flash: { alert: t('alerts.cannot_cancel_or_reschedule', days: Rails.configuration.x.schedule_up_to_days) }
+          flash: {
+            alert: t('alerts.cannot_cancel_or_reschedule',
+            days: Rails.configuration.x.schedule_up_to_days),
+            cy: 'cannotCancelOrRescheduleText'
+          }
         )
       end
 
@@ -51,7 +55,11 @@ module Community
       unless @appointment.can_cancel_and_reschedule?
         return redirect_to(
           home_community_appointments_path,
-          flash: { alert: t('alerts.cannot_cancel_or_reschedule', days: Rails.configuration.x.schedule_up_to_days) }
+          flash: {
+            alert: t('alerts.cannot_cancel_or_reschedule',
+            days: Rails.configuration.x.schedule_up_to_days),
+            cy: 'cannotCancelOrRescheduleText'
+          }
         )
       end
 

--- a/app/controllers/community/appointments_controller.rb
+++ b/app/controllers/community/appointments_controller.rb
@@ -23,8 +23,7 @@ module Community
         return redirect_to(
           home_community_appointments_path,
           flash: {
-            alert: t('alerts.cannot_cancel_or_reschedule',
-            days: Rails.configuration.x.schedule_up_to_days),
+            alert: t('alerts.cannot_cancel_or_reschedule', days: Rails.configuration.x.schedule_up_to_days),
             cy: 'cannotCancelOrRescheduleText'
           }
         )
@@ -56,8 +55,7 @@ module Community
         return redirect_to(
           home_community_appointments_path,
           flash: {
-            alert: t('alerts.cannot_cancel_or_reschedule',
-            days: Rails.configuration.x.schedule_up_to_days),
+            alert: t('alerts.cannot_cancel_or_reschedule', days: Rails.configuration.x.schedule_up_to_days),
             cy: 'cannotCancelOrRescheduleText'
           }
         )

--- a/app/controllers/community/patients_controller.rb
+++ b/app/controllers/community/patients_controller.rb
@@ -41,6 +41,7 @@ module Community
       @patient.attributes = update_params
 
       if cannot_update_profile?
+        flash.now[:cy] = 'cannotUpdateProfileDueToAppointmentConditionText'
         flash.now[:alert] = t('alerts.cannot_update_profile_due_to_appointment_condition')
         render :edit
         return

--- a/spec/cypress/app_commands/scenarios/second_dose_patient.rb
+++ b/spec/cypress/app_commands/scenarios/second_dose_patient.rb
@@ -11,7 +11,7 @@ Patient.create!(
 ).tap do |patient|
   ubs = Ubs.first!
 
-  patient.appointments.create!(
+  first_appointment = patient.appointments.create!(
     start: Time.zone.yesterday.at_beginning_of_day,
     end: Time.zone.yesterday.at_beginning_of_day,
     vaccine_name: 'coronavac',
@@ -22,12 +22,20 @@ Patient.create!(
   )
 
   patient.appointments.create!(
-    start: Time.zone.today.end_of_day - 15.minutes,
-    end: Time.zone.today.end_of_day,
+    start: command_options['days_from_now'].days.from_now.end_of_day - 15.minutes,
+    end: command_options['days_from_now'].days.from_now.end_of_day,
     vaccine_name: 'coronavac',
     check_in: nil,
     check_out: nil,
     active: true,
     ubs: ubs
   )
+
+  vaccine = Vaccine.find_by!(legacy_name: 'coronavac')
+  sequence_number = patient.doses.where(vaccine: vaccine).count
+  patient.doses.create! appointment: first_appointment,
+                        vaccine: vaccine,
+                        sequence_number: sequence_number + 1,
+                        created_at: first_appointment.check_out,
+                        updated_at: first_appointment.check_out
 end

--- a/spec/cypress/app_commands/seed.rb
+++ b/spec/cypress/app_commands/seed.rb
@@ -1,1 +1,3 @@
 system 'rails db:seed'
+system 'rails seeding:vaccines'
+system 'rails backfill:vaccines'

--- a/spec/cypress/integration/operator/reception.js
+++ b/spec/cypress/integration/operator/reception.js
@@ -42,7 +42,7 @@ describe('reception flow', () => {
     const cpf = '71143168011'
 
     beforeEach(() => {
-      cy.appScenario('second_dose_patient', { cpf: cpf });
+      cy.appScenario('second_dose_patient', { cpf: cpf, days_from_now: 0 });
       cy.get('[data-cy=waitingListTab]').click()
       cy.get('[data-cy=searchInput]').type('second dose marvin')
       cy.get('[data-cy=searchSubmit]').click()

--- a/spec/cypress/integration/patient/appointment.js
+++ b/spec/cypress/integration/patient/appointment.js
@@ -143,6 +143,13 @@ describe('patient appointment flow', () => {
         cy.get('[data-cy=scheduledAppointmentText]').should('exist')
         cy.get('[data-cy=cannotCancelOrRescheduleText]').should('exist')
       })
+
+      it('can not reschedule second dose before it reaches the permitted day period', () => {
+        cy.get('[data-cy=appointmentRescheduleButton]').click()
+
+        cy.get('[data-cy=scheduledAppointmentText]').should('exist')
+        cy.get('[data-cy=cannotCancelOrRescheduleText]').should('exist')
+      })
     })
   })
 

--- a/spec/cypress/integration/patient/appointment.js
+++ b/spec/cypress/integration/patient/appointment.js
@@ -48,6 +48,20 @@ describe('patient appointment flow', () => {
       cy.loginAsPatient(cpf)
     })
 
+    context('when patient has a scheduled appointment and tries to update itself to a not permitted patient scenario', () => {
+      it('does not update the patient and shows the not permitted action text', () => {
+        cy.get('[data-cy=appointmentRescheduleButton]').click()
+        cy.get('[data-cy=nextDayButton]').click()
+        cy.get('[data-cy=ubs1Button]').click()
+        cy.get('#ubs1 [data-cy=scheduleTimeButton]:first').click()
+
+        cy.get('[data-cy=patientEditButton]').click()
+        cy.get('#patient_birthday_1i').select('2000')
+        cy.get('[data-cy=patientSubmitButton]').click()
+        cy.get('[data-cy=cannotUpdateProfileDueToAppointmentConditionText]').should('exist')
+      })
+    })
+
     context('when there are doses', () => {
       it('can schedule, reschedule, and cancel', () => {
         cy.get('[data-cy=dosesAvailableText]').should('exist')
@@ -85,33 +99,52 @@ describe('patient appointment flow', () => {
   })
 
   context('when patient is a second dose patient', () => {
-    beforeEach(() => {
-      cy.appScenario('second_dose_patient', {cpf: cpf});
-      cy.visit('/')
+    context('when second dose is tomorrow', () => {
+      beforeEach(() => {
+        cy.appScenario('second_dose_patient', { cpf: cpf, days_from_now: 1 });
+        cy.visit('/')
 
-      cy.loginAsPatient(cpf)
+        cy.loginAsPatient(cpf)
+      })
+
+      it('can cancel and reschedule setting the same vaccine', () => {
+        cy.get('[data-cy=appliedVaccineName]').should('contain', 'Coronavac')
+
+        // Reschedule
+        cy.get('[data-cy=appointmentRescheduleButton]').click()
+        cy.get('[data-cy=nextDayButton]').click()
+        cy.get('[data-cy=ubs1Button]').click()
+        cy.get('#ubs1 [data-cy=scheduleTimeButton]:first').click()
+        cy.get('[data-cy=appliedVaccineName]').should('contain', 'Coronavac')
+
+        // Cancel and re-schedule
+        cy.get('[data-cy=appointmentCancelButton]').click()
+        cy.get('[data-cy=appointmentRescheduleButton]').click()
+        cy.get('[data-cy=nextDayButton]').click()
+        cy.get('[data-cy=ubs1Button]').click()
+        cy.get('#ubs1 [data-cy=scheduleTimeButton]:first').click()
+        cy.get('[data-cy=scheduledAppointmentText]').should('exist')
+
+        cy.get('[data-cy=appliedVaccineName]').should('contain', 'Coronavac')
+      })
     })
 
-    it('can replace same vaccine, and cancel and reschedule', () => {
-      cy.get('[data-cy=appliedVaccineName]').should('contain', 'Coronavac')
+    context('when second dose is far away', () => {
+      beforeEach(() => {
+        cy.appScenario('second_dose_patient', { cpf: cpf, days_from_now: 30 });
+        cy.visit('/')
 
-      // Reschedule button
-      cy.get('[data-cy=appointmentRescheduleButton]').click()
-      cy.get('[data-cy=nextDayButton]').click()
-      cy.get('[data-cy=ubs1Button]').click()
-      cy.get('#ubs1 [data-cy=scheduleTimeButton]:first').click()
-      cy.get('[data-cy=appliedVaccineName]').should('contain', 'Coronavac')
+        cy.loginAsPatient(cpf)
+      })
 
-      // Cancel and re-schedule
-      cy.get('[data-cy=appointmentCancelButton]').click()
-      cy.get('[data-cy=appointmentRescheduleButton]').click()
-      cy.get('[data-cy=nextDayButton]').click()
-      cy.get('[data-cy=ubs1Button]').click()
-      cy.get('#ubs1 [data-cy=scheduleTimeButton]:first').click()
-      cy.get('[data-cy=scheduledAppointmentText]').should('exist')
+      it('can not cancel second dose before it reaches the permitted day period', () => {
+        cy.get('[data-cy=appointmentCancelButton]').click()
 
-      cy.get('[data-cy=appliedVaccineName]').should('contain', 'Coronavac')
+        cy.get('[data-cy=scheduledAppointmentText]').should('exist')
+        cy.get('[data-cy=cannotCancelOrRescheduleText]').should('exist')
+      })
     })
+
   })
 
   context('when patient is already vaccinated', () => {

--- a/spec/cypress/integration/patient/appointment.js
+++ b/spec/cypress/integration/patient/appointment.js
@@ -144,7 +144,6 @@ describe('patient appointment flow', () => {
         cy.get('[data-cy=cannotCancelOrRescheduleText]').should('exist')
       })
     })
-
   })
 
   context('when patient is already vaccinated', () => {


### PR DESCRIPTION
Correndo atrás das features do @jmonteiro  :sweat_smile: 

Aqui estamos passando a cobrir:
- paciente que agenda e depois edita o perfil para um escopo não permitido (espertão)
- paciente que tenta cancelar a segunda dose para reagendar mais próximo (espertão 2)

Também chamei as rakes no seed. Acho qu não onerou muito o tempo de testes mas podemos rever.


Falta ainda o scenario de aniversário próximo da data de vacinação. Vou fazer em outro PR