### PR TITLE
Restrict the second dose appointment cancelled to be reschedule

### DIFF
--- a/app/services/appointment_scheduler.rb
+++ b/app/services/appointment_scheduler.rb
@@ -64,14 +64,12 @@ class AppointmentScheduler
       patient.appointments
              .waiting
              .where(id: id)
-             .update_all(patient_id: nil, vaccine_name: nil, active: false, updated_at: Time.zone.now)
+             .update_all(patient_id: nil, vaccine_name: nil, active: false, updated_at: Time.zone.now) # rubocop:disable Rails/SkipsModelValidations
     else
       patient.appointments
              .waiting
              .where(id: id)
-             .update_all(
-               patient_id: nil, vaccine_name: nil, updated_at: Time.zone.now
-              ) # rubocop:disable Rails/SkipsModelValidations
+             .update_all(patient_id: nil, vaccine_name: nil, updated_at: Time.zone.now) # rubocop:disable Rails/SkipsModelValidations
     end
   end
 

--- a/app/services/appointment_scheduler.rb
+++ b/app/services/appointment_scheduler.rb
@@ -60,10 +60,17 @@ class AppointmentScheduler
 
   # Cancels schedule for an appointment for a given patient, in a SQL efficient way
   def cancel_schedule(patient:, id:)
-    patient.appointments
-           .waiting
-           .where(id: id)
-           .update_all(patient_id: nil, vaccine_name: nil, updated_at: Time.zone.now) # rubocop:disable Rails/SkipsModelValidations
+    if patient.doses.exists?
+      patient.appointments
+            .waiting
+            .where(id: id)
+            .update_all(patient_id: nil, vaccine_name: nil, active: false, updated_at: Time.zone.now)
+    else
+      patient.appointments
+            .waiting
+            .where(id: id)
+            .update_all(patient_id: nil, vaccine_name: nil, updated_at: Time.zone.now) # rubocop:disable Rails/SkipsModelValidations
+    end
   end
 
   def open_times_per_ubs(from:, to:)

--- a/app/services/appointment_scheduler.rb
+++ b/app/services/appointment_scheduler.rb
@@ -62,14 +62,16 @@ class AppointmentScheduler
   def cancel_schedule(patient:, id:)
     if patient.doses.exists?
       patient.appointments
-            .waiting
-            .where(id: id)
-            .update_all(patient_id: nil, vaccine_name: nil, active: false, updated_at: Time.zone.now)
+             .waiting
+             .where(id: id)
+             .update_all(patient_id: nil, vaccine_name: nil, active: false, updated_at: Time.zone.now)
     else
       patient.appointments
-            .waiting
-            .where(id: id)
-            .update_all(patient_id: nil, vaccine_name: nil, updated_at: Time.zone.now) # rubocop:disable Rails/SkipsModelValidations
+             .waiting
+             .where(id: id)
+             .update_all(
+               patient_id: nil, vaccine_name: nil, updated_at: Time.zone.now
+              ) # rubocop:disable Rails/SkipsModelValidations
     end
   end
 


### PR DESCRIPTION
PR to Restrict the second dose appointment cancelled to be reschedule, to handle with this rule:

"Regra da vaga deixada (cancelada): NÃO PODE SER USADA POR NENHUM OUTRO PACIENTE." ALBINO, Denis.
