### PR TITLE
Validating CPF input from community entry page

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,6 +4,7 @@
 
 $(document).ready(function(){
   $('.sp-celphones').mask(SPMaskBehavior, spOptions);
+  $('input[type="cpf"]').mask('999.999.999-99');
 });
 
 var SPMaskBehavior = function (val) {

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,7 +4,7 @@
 
 $(document).ready(function(){
   $('.sp-celphones').mask(SPMaskBehavior, spOptions);
-  $('input[type="cpf"]').mask('999.999.999-99');
+  $('input[data-sel="cpf"]').mask('999.999.999-99');
 });
 
 var SPMaskBehavior = function (val) {

--- a/app/controllers/community/sessions_controller.rb
+++ b/app/controllers/community/sessions_controller.rb
@@ -1,5 +1,7 @@
 module Community
   class SessionsController < Base
+    before_action -> { redirect_to root_path, alert: 'CPF inválido' }, unless: -> { CPF.valid?(session_params[:cpf]) }
+
     skip_before_action :authenticate!, only: %i[create destroy]
 
     def create

--- a/app/controllers/community/sessions_controller.rb
+++ b/app/controllers/community/sessions_controller.rb
@@ -1,8 +1,7 @@
 module Community
   class SessionsController < Base
     skip_before_action :authenticate!, only: %i[create destroy]
-
-    before_action -> { redirect_to root_path, alert: 'CPF inválido' }, unless: -> { CPF.valid?(session_params[:cpf]) }, only: %i[create]
+    before_action :validate_cpf_input, only: %i[create]
 
     def create
       @patient = Patient.find_by(cpf: parse_cpf)
@@ -27,6 +26,10 @@ module Community
     end
 
     protected
+
+    def validate_cpf_input
+      redirect_to root_path, alert: 'CPF inválido' unless CPF.valid?(session_params[:cpf])
+    end
 
     def parse_cpf
       Patient.parse_cpf session_params[:cpf]

--- a/app/controllers/community/sessions_controller.rb
+++ b/app/controllers/community/sessions_controller.rb
@@ -1,8 +1,8 @@
 module Community
   class SessionsController < Base
-    before_action -> { redirect_to root_path, alert: 'CPF inválido' }, unless: -> { CPF.valid?(session_params[:cpf]) }
-
     skip_before_action :authenticate!, only: %i[create destroy]
+
+    before_action -> { redirect_to root_path, alert: 'CPF inválido' }, unless: -> { CPF.valid?(session_params[:cpf]) }, only: %i[create]
 
     def create
       @patient = Patient.find_by(cpf: parse_cpf)

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -64,14 +64,12 @@
               <div class="input-group-text">CPF</div>
             </div>
             <%= f.text_field :cpf,
-                             autofocus: true,
                              minlength: 11, maxlength: 14,
                              required: true,
-                             type: :cpf,
                              class: "form-control form-control-lg",
                              aria: { describedby: 'cpfHelpInLine' },
                              placeholder: '000.000.000-00',
-                             data: { cy: "cpfInputField" } %>
+                             data: { cy: "cpfInputField", sel: "cpf" } %>
             <div class="input-group-append">
               <%= f.submit "Acessar",
                            class: "btn btn-primary",

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -67,6 +67,7 @@
                              autofocus: true,
                              minlength: 11, maxlength: 14,
                              required: true,
+                             type: :cpf,
                              class: "form-control form-control-lg",
                              aria: { describedby: 'cpfHelpInLine' },
                              placeholder: '000.000.000-00',


### PR DESCRIPTION
Ao entrar com um CPF inválido o sistema redireciona para completar o cadastro mas não permite a edição do CPF.

Neste PR foi incluída uma validação do lado do cliente e outra no servidor antes de redirecionar o paciente para finalizar o cadastro.

## :computer: SCREENSHOTS

Página de entrada:
![invalid-cpf-1](https://user-images.githubusercontent.com/607276/117829440-22bb7780-b249-11eb-9e7c-1c11f6f80e16.png)

Página para completar cadastro:
![invalid-cpf-2](https://user-images.githubusercontent.com/607276/117829459-2818c200-b249-11eb-9886-02e56d75efb0.png)

