### PR TITLE
Carregar usuário da sessão apenas uma vez por requisição

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,9 +5,8 @@ class ApplicationController < ActionController::Base
 
   def current_patient
     return if session[:patient_id].blank?
-    return @current_patient if @current_patient.present?
 
-    @current_patient = Patient.find session[:patient_id]
+    @current_patient ||= Patient.find session[:patient_id]
   end
 
   def date_from_params(params, date_key)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
 
   def current_patient
     return if session[:patient_id].blank?
+    return @current_patient if @current_patient.present?
 
     @current_patient = Patient.find session[:patient_id]
   end


### PR DESCRIPTION
Hoje o usuário é buscado na base toda vez que o método `ApplicationController#current_patient` é chamado. Com esse PR, ele reutiliza a instância.