### PR TITLE
Pequena correção do readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Caso você queira instalar manualmente todas as dependências no seu ambiente GN
 precisará executar os seguintes comandos:
 
 ```sh
-apt-get update
-apt-get postgresql postgresql-contrib postgresql-server-dev-all cmake nodejs libpq-dev
+apt update
+apt install postgresql postgresql-contrib postgresql-server-dev-all cmake nodejs libpq-dev
 gem install bundler
 ```
 


### PR DESCRIPTION
Durante a declaração da instalação manual faltou o `install` na segunda linha, também tomei a liberdade de remover o -get visto que atualmente é opcional