### PR TITLE
Alterando regra para ver todos os pacientes bloqueados

### DIFF
--- a/app/controllers/admin/patients_controller.rb
+++ b/app/controllers/admin/patients_controller.rb
@@ -11,10 +11,15 @@ module Admin
 
     # For now, only showing locked patients
     def index
-      @patients = filter(search(Patient.order(:cpf)))
-                  .order(Patient.arel_table[:name].lower.asc)
-                  .page(index_params[:page])
-                  .per(100)
+      if index_params[:search].present? && index_params[:search].size >= 1
+        @patients = search(Patient.order(:cpf))
+      else
+        @patients = filter(Patient.order(:cpf))
+      end
+      
+      @patients = @patients.order(Patient.arel_table[:name].lower.asc)
+                    .page(index_params[:page])
+                    .per(100)
     end
 
     def new
@@ -60,19 +65,15 @@ module Admin
       when FILTERS[:locked]
         patients.locked
       else
-        patients
+        patients.where('TRUE IS FALSE') # For now, return nothing
       end
     end
 
     # Searches for specific patients
     def search(patients)
-      if index_params[:search].present? && index_params[:search].size >= 1
-        @filter = FILTERS[:search] # In case we're searching, use special filter
-        @search = index_params[:search]
-        return patients.search_for(@search)
-      end
-
-      patients.where('TRUE IS FALSE') # to return empty
+      @filter = FILTERS[:search] # In case we're searching, use special filter
+      @search = index_params[:search]
+      return patients.search_for(@search)
     end
 
     def set_patient

--- a/app/controllers/admin/patients_controller.rb
+++ b/app/controllers/admin/patients_controller.rb
@@ -16,10 +16,10 @@ module Admin
       else
         @patients = filter(Patient.order(:cpf))
       end
-      
+
       @patients = @patients.order(Patient.arel_table[:name].lower.asc)
-                    .page(index_params[:page])
-                    .per(100)
+                           .page(index_params[:page])
+                           .per(100)
     end
 
     def new
@@ -73,7 +73,7 @@ module Admin
     def search(patients)
       @filter = FILTERS[:search] # In case we're searching, use special filter
       @search = index_params[:search]
-      return patients.search_for(@search)
+      patients.search_for(@search)
     end
 
     def set_patient

--- a/app/controllers/admin/patients_controller.rb
+++ b/app/controllers/admin/patients_controller.rb
@@ -11,11 +11,11 @@ module Admin
 
     # For now, only showing locked patients
     def index
-      if index_params[:search].present? && index_params[:search].size >= 1
-        @patients = search(Patient.order(:cpf))
-      else
-        @patients = filter(Patient.order(:cpf))
-      end
+      @patients = if index_params[:search].present? && index_params[:search].size >= 1
+                    search(Patient.order(:cpf))
+                  else
+                    filter(Patient.order(:cpf))
+                  end
 
       @patients = @patients.order(Patient.arel_table[:name].lower.asc)
                            .page(index_params[:page])

--- a/app/controllers/admin/patients_controller.rb
+++ b/app/controllers/admin/patients_controller.rb
@@ -11,15 +11,9 @@ module Admin
 
     # For now, only showing locked patients
     def index
-      @patients = if index_params[:search].present? && index_params[:search].size >= 1
-                    search(Patient.order(:cpf))
-                  else
-                    filter(Patient.order(:cpf))
-                  end
-
-      @patients = @patients.order(Patient.arel_table[:name].lower.asc)
-                           .page(index_params[:page])
-                           .per(100)
+      @patients = filter_search(Patient.order(:cpf)).order(Patient.arel_table[:name].lower.asc)
+                                                    .page(index_params[:page])
+                                                    .per(100)
     end
 
     def new
@@ -74,6 +68,14 @@ module Admin
       @filter = FILTERS[:search] # In case we're searching, use special filter
       @search = index_params[:search]
       patients.search_for(@search)
+    end
+
+    def filter_search(patients)
+      if index_params[:search].present? && index_params[:search].size >= 1
+        search(patients)
+      else
+        filter(patients)
+      end
     end
 
     def set_patient

--- a/config/locales/models/pt-BR.yml
+++ b/config/locales/models/pt-BR.yml
@@ -12,7 +12,7 @@
     patients:
       state:
         all: "Todos" # used as a filter on Admin's Patient's index
-        locked: "Bloqueado"
+        locked: "Bloqueados"
     appointments:
       state:
         all: "Agendamentos para hoje" # used as a filter on Operator's Appointment's index


### PR DESCRIPTION
### Resolve Issue #375 

Alterado a lógica de exibição para mostrar todos os pacientes bloqueados ao clicar na aba / filtro **Bloqueado**, conforme imagem abaixo:

![image](https://user-images.githubusercontent.com/19494561/126576554-93949705-4280-4e2e-856c-feb81e4b8af1.png)

