### PR TITLE
Redirect instead of raise exception

### DIFF
--- a/app/controllers/community/appointments_controller.rb
+++ b/app/controllers/community/appointments_controller.rb
@@ -42,6 +42,8 @@ module Community
                                .sort_by { |ubs, _appointments| ubs.name }
     rescue AppointmentScheduler::NoFreeSlotsAhead
       redirect_to home_community_appointments_path, flash: { alert: 'Não há vagas disponíveis para reagendamento.' }
+    rescue CannotCancelAndReschedule
+      redirect_to home_community_appointments_path, flash: { alert: 'Você não pode cancelar ou reagendar.' }
     end
     # rubocop:enable Metrics/AbcSize
 
@@ -63,6 +65,8 @@ module Community
 
       redirect_to home_community_appointments_path,
                   flash: message_for(result, appointment: new_appointment, desired_start: parse_start)
+    rescue CannotCancelAndReschedule
+      redirect_to home_community_appointments_path, flash: { alert: 'Você não pode cancelar ou reagendar.' }
     end
     # rubocop:enable Metrics/AbcSize
 


### PR DESCRIPTION
Em https://appsignal.com/agenda-saude/sites/609dec760f9875392a866c0e/exceptions/incidents/35?timerange=2021-07-26T06%3A00%3A00.000Z%2C+2021-07-26T07%3A00%3A00.000Z&incident_tab=host é possível notar que um paciente está com script que roda 100x por hora tentativa de reagendar sua segunda dose, o que está poluindo o AppSignal com excessões. Este código faz com que o erro seja convertido em um redirecionamento de página.