### PR TITLE
Condicao alterada para reagendamento segunda dose

### DIFF
--- a/app/controllers/admin/ubs_controller.rb
+++ b/app/controllers/admin/ubs_controller.rb
@@ -52,7 +52,7 @@ module Admin
         :saturday_shift_start, :saturday_break_start, :saturday_break_end, :saturday_shift_end,
         :sunday_shift_start, :sunday_break_start, :sunday_break_end, :sunday_shift_end,
         :slot_interval_minutes, :appointments_per_time_slot,
-        :address, :neighborhood_id, :phone
+        :address, :neighborhood_id, :phone, :enabled_for_reschedule
       )
     end
 

--- a/app/controllers/community/appointments_controller.rb
+++ b/app/controllers/community/appointments_controller.rb
@@ -31,15 +31,18 @@ module Community
       # If patient already had a dose, show only UBS that are 'enabled_for_reschedule'.
       if current_patient.doses.exists?
         ubs_id = Ubs.where(enabled_for_reschedule: true).pluck(:id)
+        rescheduled = true
       else
         # Otherwise limit to where they can schedule
         ubs_id = allowed_ubs_ids
+        rescheduled = false
       end
 
       @days = parse_days
       @appointments = scheduler.open_times_per_ubs(from: @days.days.from_now.beginning_of_day,
                                                    to: @days.days.from_now.end_of_day,
-                                                   filter_ubs_id: ubs_id)
+                                                   filter_ubs_id: ubs_id,
+                                                   reschedule: rescheduled)
                                .sort_by { |ubs, _appointments| ubs.name }
     rescue AppointmentScheduler::NoFreeSlotsAhead
       redirect_to home_community_appointments_path, flash: { alert: 'Não há vagas disponíveis para reagendamento.' }
@@ -53,15 +56,25 @@ module Community
       appointment_can_cancel_and_reschedule
 
       # If patient already had a dose, keep it in the same UBS
-      ubs_id = current_patient.doses.first&.appointment&.ubs_id
+      if current_patient.doses.exists?
+        ubs_id = create_params[:ubs_id].to_i
+        rescheduled = true
 
       # Intersection between allowed and requested, will return nil (which is fine) if forbidden
-      ubs_id = (allowed_ubs_ids & [create_params[:ubs_id].to_i]).first if ubs_id.blank? && create_params[:ubs_id]
+      else
+        ubs_id = (allowed_ubs_ids & [create_params[:ubs_id].to_i]).first if ubs_id.blank? && create_params[:ubs_id]
+        rescheduled = false
+      end
+      
+      # ubs_id = current_patient.doses.first&.appointment&.ubs_id
+
+      # ubs_id = (allowed_ubs_ids & [create_params[:ubs_id].to_i]).first if ubs_id.blank? && create_params[:ubs_id]
 
       result, new_appointment = scheduler.schedule(
         patient: current_patient,
         ubs_id: ubs_id,
-        from: parse_start.presence
+        from: parse_start.presence,
+        reschedule: rescheduled
       )
 
       redirect_to home_community_appointments_path,

--- a/app/controllers/community/appointments_controller.rb
+++ b/app/controllers/community/appointments_controller.rb
@@ -28,9 +28,8 @@ module Community
     def index
       appointment_can_cancel_and_reschedule
 
-      # If patient already had a dose, keep it in the same UBS.
-      # This is an optimized query, hence a little odd using +pick+s.
-      ubs_id = Appointment.where(id: current_patient.doses.pick(:appointment_id)).pick(:ubs_id)
+      # If patient already had a dose, show only UBS that are 'enabled_for_reschedule'.
+      ubs_id = Ubs.where(enabled_for_reschedule: true).pluck(:id) if current_patient.doses.exists?
 
       # Otherwise limit to where they can schedule
       ubs_id = allowed_ubs_ids if ubs_id.blank?

--- a/app/controllers/community/appointments_controller.rb
+++ b/app/controllers/community/appointments_controller.rb
@@ -33,7 +33,7 @@ module Community
         ubs_id = Ubs.where(enabled_for_reschedule: true).pluck(:id)
       else
         # Otherwise limit to where they can schedule
-        ubs_id = allowed_ubs_ids if ubs_id.blank?
+        ubs_id = allowed_ubs_ids
       end
 
       @days = parse_days

--- a/app/controllers/community/appointments_controller.rb
+++ b/app/controllers/community/appointments_controller.rb
@@ -29,10 +29,12 @@ module Community
       appointment_can_cancel_and_reschedule
 
       # If patient already had a dose, show only UBS that are 'enabled_for_reschedule'.
-      ubs_id = Ubs.where(enabled_for_reschedule: true).pluck(:id) if current_patient.doses.exists?
-
-      # Otherwise limit to where they can schedule
-      ubs_id = allowed_ubs_ids if ubs_id.blank?
+      if current_patient.doses.exists?
+        ubs_id = Ubs.where(enabled_for_reschedule: true).pluck(:id)
+      else
+        # Otherwise limit to where they can schedule
+        ubs_id = allowed_ubs_ids if ubs_id.blank?
+      end
 
       @days = parse_days
       @appointments = scheduler.open_times_per_ubs(from: @days.days.from_now.beginning_of_day,

--- a/app/controllers/community/appointments_controller.rb
+++ b/app/controllers/community/appointments_controller.rb
@@ -65,10 +65,6 @@ module Community
         ubs_id = (allowed_ubs_ids & [create_params[:ubs_id].to_i]).first if ubs_id.blank? && create_params[:ubs_id]
         rescheduled = false
       end
-      
-      # ubs_id = current_patient.doses.first&.appointment&.ubs_id
-
-      # ubs_id = (allowed_ubs_ids & [create_params[:ubs_id].to_i]).first if ubs_id.blank? && create_params[:ubs_id]
 
       result, new_appointment = scheduler.schedule(
         patient: current_patient,

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -56,11 +56,9 @@ class Appointment < ApplicationRecord
     Time.zone.now > can_change_after
   end
 
-  # Patients can only cancel or reschedule after a certain cutoff, in this case being "schedule_up_to_days" related with
-  # when they should get the vaccine.
+  # Patients can only cancel or reschedule after the date of next scheduled dose
   def can_change_after
-    follow_up_for_dose.created_at + follow_up_for_dose.follow_up_in_days.days -
-      Rails.configuration.x.schedule_up_to_days.days
+    start
   end
 
   def in_allowed_check_in_window?

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -51,7 +51,7 @@ class Patient < ApplicationRecord
 
   # Find if any conditions match
   def can_schedule?
-    conditions.any?
+    got_first_dose? || conditions.any?
   end
 
   # Find if patient was every able to schedule in the past

--- a/app/services/appointment_scheduler.rb
+++ b/app/services/appointment_scheduler.rb
@@ -37,9 +37,14 @@ class AppointmentScheduler
       )
       return [NO_SLOTS] unless success
 
-      new_appointment = patient.appointments.waiting.where.not(id: current_appointment&.id).first!
-      cancel_schedule(appointment: current_appointment, new_appointment: new_appointment) if current_appointment
+      if reschedule
+        new_appointment = patient.appointments.waiting.last!
+      else
+        new_appointment = patient.appointments.waiting.where.not(id: current_appointment&.id).first!
+      end
 
+      cancel_schedule(appointment: current_appointment, new_appointment: new_appointment) if current_appointment
+      
       # In case patient canceled a follow up in the past and is trying to reschedule it
       dose = patient.doses.where(follow_up_appointment: nil).first
       dose&.update!(follow_up_appointment: new_appointment)

--- a/app/services/appointment_scheduler.rb
+++ b/app/services/appointment_scheduler.rb
@@ -22,7 +22,7 @@ class AppointmentScheduler
   # Looks for appointments, and tries to schedule one. If it can't, it will return +NO_SLOTS+.
   # In case it can, it will also cancel the patient's current schedule for an existing appointment, and in the end it
   # returns +SUCCESS+ and the newly scheduled appointment.
-  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
   def schedule(patient:, ubs_id:, from:, reschedule:)
     return [CONDITIONS_UNMET] unless patient.can_schedule?
 
@@ -44,7 +44,7 @@ class AppointmentScheduler
       end
 
       cancel_schedule(appointment: current_appointment, new_appointment: new_appointment) if current_appointment
-      
+
       # In case patient canceled a follow up in the past and is trying to reschedule it
       dose = patient.doses.where(follow_up_appointment: nil).first
       dose&.update!(follow_up_appointment: new_appointment)
@@ -57,7 +57,7 @@ class AppointmentScheduler
 
     [NO_SLOTS]
   end
-  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
   def log(action, patient_id, appointment_id)
     Rails.logger.info "[AppointmentScheduler logger] patient #{patient_id} appointment #{appointment_id}: #{action}"

--- a/app/views/admin/ubs/_form.html.erb
+++ b/app/views/admin/ubs/_form.html.erb
@@ -100,6 +100,11 @@
       <%= f.label :appointments_per_time_slot, class: 'small' %>
       <%= f.select :appointments_per_time_slot, 1..200, {}, class: "form-control" %>
     </div>
+
+    <div class="form-group col-md-4">
+      <%= f.label :enabled_for_reschedule, class: 'small' %>
+      <%= f.check_box :enabled_for_reschedule, class: "form-control" %>
+    </div>
   </div>
 
   <h5>Endereço</h5>

--- a/app/views/admin/ubs/index.html.erb
+++ b/app/views/admin/ubs/index.html.erb
@@ -13,10 +13,11 @@
   <tr>
     <th scope="col">#</th>
     <th scope="col">Nome</th>
-    <th scope="col">Domingo</th>
     <th scope="col">2<sup>a</sup>-6<sup>a</sup></th>
     <th scope="col">Sábado</th>
+    <th scope="col">Domingo</th>
     <th scope="col">Ativa?</th>
+    <th scope="col">Hab. p/ Reagendamento dose reforço?</th>
   </tr>
   </thead>
   <tbody>
@@ -29,16 +30,19 @@
         <%= link_to ubs.name, admin_ubs_path(ubs) %>
       </th>
       <td>
-        <%= human_shifts(ubs, weekday: 0) %>
-      </td>
-      <td>
         <%= human_shifts(ubs) %>
       </td>
       <td>
         <%= human_shifts(ubs, weekday: 6) %>
       </td>
       <td>
+        <%= human_shifts(ubs, weekday: 0) %>
+      </td>
+      <td>
         <%= ubs.active ? "✅" : "❌" %>
+      </td>
+      <td>
+        <%= ubs.enabled_for_reschedule ? "✅" : "❌" %>
       </td>
     </tr>
   <% end -%>

--- a/app/views/community/appointments/_home_has_appointment.html.erb
+++ b/app/views/community/appointments/_home_has_appointment.html.erb
@@ -50,7 +50,10 @@
         <% else -%>
           <div class="row">
             <div class="col">
-                <div class="alert alert-warning" role="alert" data-cy="cannotCancelAndRescheduleText">
+                <div class="alert alert-danger" role="danger" data-cy="cannotCancelAndRescheduleText">
+                  <h4 class="alert-title">
+                  <%= t("alerts.cannot_reschedule_yet_head", datetime: l(@appointment.can_change_after, format: :human)) %>
+                  </h4>
                   <%= t("alerts.cannot_reschedule_yet", datetime: l(@appointment.can_change_after, format: :human)) %>
                 </div>
             </div>

--- a/app/views/community/appointments/_home_has_appointment.html.erb
+++ b/app/views/community/appointments/_home_has_appointment.html.erb
@@ -54,7 +54,7 @@
                   <h4 class="alert-title">
                   <%= t("alerts.cannot_reschedule_yet_head", datetime: l(@appointment.can_change_after, format: :human)) %>
                   </h4>
-                  <%= t("alerts.cannot_reschedule_yet", datetime: l(@appointment.can_change_after, format: :human)) %>
+                  <%= t("alerts.cannot_reschedule_yet") %>
                 </div>
             </div>
           </div>

--- a/app/views/community/appointments/index.html.erb
+++ b/app/views/community/appointments/index.html.erb
@@ -23,9 +23,15 @@
 <div class="container">
   <div class="row">
     <div class="col">
-      <div class="alert alert-info">
-        Para agendar, escolha um dia, unidade e clique no horário disponível desejado.
-      </div>
+      <% if current_patient.doses.exists? -%>
+        <div class="alert alert-info">
+          Serão exibidas apenas as unidades definidas pela Secretaria da Saúde para receber reagendamento da dose de reforço.
+        </div>
+      <% else -%>
+        <div class="alert alert-info">
+          Para agendar, escolha um dia, unidade e clique no horário disponível desejado.
+        </div>
+      <% end -%>
     </div>
   </div>
 </div>

--- a/config/locales/views.pt-BR.yml
+++ b/config/locales/views.pt-BR.yml
@@ -68,6 +68,7 @@ pt-BR:
         sunday_break_end: Fim da pausa de almoço de Domingo
         slot_interval_minutes: Duração de cada atendimento (min)
         appointments_per_time_slot: Atendimentos em paralelo
+        enabled_for_reschedule: Habilitado para Reagendamento da dose de reforço
         address: Endereço
         neighborhood: Bairro
         phone: Telefone

--- a/config/locales/views.pt-BR.yml
+++ b/config/locales/views.pt-BR.yml
@@ -122,11 +122,10 @@ pt-BR:
     cannot_update_profile_due_to_appointment_condition: |
       Não foi possível atualizar seu cadastro, já que esta alteração irá remover você do grupo que pode receber vacinas.
       Para realizar esta alteração, primeiro cancele seu agendamento atual, para só então atualizar seu cadastro.
+    cannot_reschedule_yet_head: |
+      O cancelamento ou reagendamento só poderá ser feito após %{datetime}.
     cannot_reschedule_yet: |
-      Ainda falta muito tempo para o reforço da sua vacina. Se você deseja cancelar ou mudar a data, volte aqui a partir
-      de %{datetime} e tente novamente.
-      Lembre-se que você só pode receber o reforço da vacina na mesma unidade que recebeu a primeira dose,
-      portanto caso hajam vagas poderá escolher outro dia e horário somente na mesma unidade.
+      Caso você não possa comparecer, entre novamente no sistema após a data e hora acima e faça um novo agendamento.
     rate_limit_exceeded: |
       Você excedeu o número de acessos por minuto ao sistema. Para evitar abusos e garantir o acesso a população, aguarde um minuto e acesse novamente.
   buttons:

--- a/spec/factories/ubs_factory.rb
+++ b/spec/factories/ubs_factory.rb
@@ -12,5 +12,6 @@ FactoryBot.define do
     phone { '9999-8888' }
     address { 'Rua Principal, 256' }
     active { true }
+    enabled_for_reschedule { true }
   end
 end

--- a/spec/factories/ubs_factory.rb
+++ b/spec/factories/ubs_factory.rb
@@ -12,6 +12,5 @@ FactoryBot.define do
     phone { '9999-8888' }
     address { 'Rua Principal, 256' }
     active { true }
-    enabled_for_reschedule { true }
   end
 end

--- a/spec/features/community_patient_appointments_spec.rb
+++ b/spec/features/community_patient_appointments_spec.rb
@@ -210,7 +210,7 @@ RSpec.feature 'Patients managing their appointments' do
         expect(page).to have_content("Unidade: #{ubs.name}")
         expect(page).to have_content('Vacina: Vacina')
         expect(page).to have_content('Vacinas recebidas')
-        expect(page).not_to have_content('Ainda falta muito tempo para o reforço da sua vacina')
+        expect(page).to have_content('Ainda falta muito tempo para o reforço da sua vacina')
       end
 
       context 'no more appointments available' do


### PR DESCRIPTION
### Corrige Issue #380 

## :warning:  Dependência

depende do PR #383  para realizar a migração do BD, adicionando nova coluna `enabled_for_reschedule` na tabela **Ubs**.

## Alterações

### Paciente / Cidadão

- Agora o paciente somente pode realizar o reagendamento da segunda [/ terceira] dose após ultrapassar a data da segunda dose gerada no *checkout* da primeira dose:

![20_paciente_agendamento_aviso_edit](https://user-images.githubusercontent.com/19494561/129462038-93ec20ff-ff14-46f9-9c8a-93c94f2a370e.png)

- Ao prosseguir com o reagendamento, será informado a mensagem que somente as unidades que foram habilitadas para receber o reagendamento da dose de reforço serão exibidas.

![21_escolha_unidade_agendamento](https://user-images.githubusercontent.com/19494561/129462067-87221315-4bdc-4e67-b2b0-35c26803e9ca.png)


### User Admin

- Nova coluna adicionada para visualizar de forma prática as unidades que estão habilitadas para receberem a dose de reforço.

![22_admin_lista_unidades_coluna_reagendamento](https://user-images.githubusercontent.com/19494561/129462098-4c80cdf6-f56d-4060-ac14-7eb2389ae0ed.png)

- Formulário de edição / criação da unidade possui o campo para alterar se a mesma estará disponível para reagendamento da dose de reforço.

![23_edicao_unidade_check_reagendamento](https://user-images.githubusercontent.com/19494561/129462114-504ab0e1-102a-44e2-89f5-28953d9a17bd.png)


