### PR TITLE
Possibilitando reagendar apos cancelamento de D2

### DIFF
--- a/app/services/appointment_scheduler.rb
+++ b/app/services/appointment_scheduler.rb
@@ -99,11 +99,13 @@ class AppointmentScheduler
   end
 
   # Returns how many days ahead there are available appointments
-  def days_ahead_with_open_slot
-    next_available_appointment = Appointment.available_doses
-                                            .where(start: earliest_allowed..latest_allowed)
-                                            .order(:start)
-                                            .pick(:start)
+  def days_ahead_with_open_slot(reschedule: false)
+    appointments = Appointment.waiting.not_scheduled if reschedule
+    appointments ||= Appointment.available_doses    
+
+    next_available_appointment = appointments.where(start: earliest_allowed..latest_allowed)
+                                             .order(:start)
+                                             .pick(:start)
 
     raise NoFreeSlotsAhead unless next_available_appointment
 


### PR DESCRIPTION
## Problema

Paciente que possui uma segunda dose agendada e que tenha passado a data de realizar a D2, ao cancelar seu agendamento da segunda dose para posterior agendamento da D2 não poderia realizar devido a lógica da aplicação atualmente.

### Vídeo ilustrando o problema
https://user-images.githubusercontent.com/19494561/132047985-52b4cd80-3c13-4fec-b977-1544da33dcbb.mp4

### Vídeo da condição alterada neste PR
https://user-images.githubusercontent.com/19494561/132048111-a5f09a03-268c-4c6a-96c1-3c6d48815c3e.mp4

 

