### PR TITLE
New reschedule schema pfizer

### DIFF
--- a/app/controllers/community/appointments_controller.rb
+++ b/app/controllers/community/appointments_controller.rb
@@ -15,6 +15,7 @@ module Community
 
       if @appointment.present?
         @can_cancel_or_reschedule = can_cancel_and_reschedule?
+        @can_change_after = current_patient.change_reschedule_after
         return
       end
 

--- a/app/controllers/community/appointments_controller.rb
+++ b/app/controllers/community/appointments_controller.rb
@@ -2,7 +2,7 @@ module Community
   class AppointmentsController < Base
     class CannotCancelAndReschedule < StandardError; end
 
-    # rubocop:disable Metrics/AbcSize Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def home
       if current_patient.force_user_update?
         return redirect_to(edit_community_patient_path, flash: { alert: I18n.t('alerts.update_patient_profile') })
@@ -31,7 +31,7 @@ module Community
                                          .count
       end
     end
-    # rubocop:enable Metrics/AbcSize Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
     # Schedules appointment
     # rubocop:disable Metrics/AbcSize

--- a/app/controllers/community/appointments_controller.rb
+++ b/app/controllers/community/appointments_controller.rb
@@ -12,7 +12,6 @@ module Community
 
       @doses = current_patient.doses.includes(:vaccine, appointment: [:ubs])
       @appointment = current_patient.appointments.current
-
       if @appointment.present?
         @can_cancel_or_reschedule = can_cancel_and_reschedule?
         @can_change_after = current_patient.change_reschedule_after
@@ -106,21 +105,18 @@ module Community
     private
 
     def appointment_can_cancel_and_reschedule
-      raise CannotCancelAndReschedule if !can_cancel_and_reschedule?
+      raise CannotCancelAndReschedule unless can_cancel_and_reschedule?
 
-      current_appointment = current_patient.appointments.not_checked_out.current
-      current_appointment
+      current_patient.appointments.not_checked_out.current
     end
 
     def can_cancel_and_reschedule?
       current_appointment = current_patient.appointments.not_checked_out.current
 
       if current_patient.doses.exists?
-        return false if !current_patient.got_reschedule_condition?
-      else
-        if current_appointment.present?
-          return false if current_appointment.follow_up_for_dose && Time.zone.now < current_appointment.start
-        end
+        return false unless current_patient.got_reschedule_condition?
+      elsif current_appointment.present?
+        return false if current_appointment.follow_up_for_dose && Time.zone.now < current_appointment.start
       end
 
       true

--- a/app/controllers/community/appointments_controller.rb
+++ b/app/controllers/community/appointments_controller.rb
@@ -2,7 +2,7 @@ module Community
   class AppointmentsController < Base
     class CannotCancelAndReschedule < StandardError; end
 
-    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/AbcSize Metrics/MethodLength
     def home
       if current_patient.force_user_update?
         return redirect_to(edit_community_patient_path, flash: { alert: I18n.t('alerts.update_patient_profile') })
@@ -12,6 +12,7 @@ module Community
 
       @doses = current_patient.doses.includes(:vaccine, appointment: [:ubs])
       @appointment = current_patient.appointments.current
+
       if @appointment.present?
         @can_cancel_or_reschedule = can_cancel_and_reschedule?
         @can_change_after = current_patient.change_reschedule_after
@@ -30,7 +31,7 @@ module Community
                                          .count
       end
     end
-    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/AbcSize Metrics/MethodLength
 
     # Schedules appointment
     # rubocop:disable Metrics/AbcSize

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -68,21 +68,22 @@ class Patient < ApplicationRecord
 
   # Flow to know if patient was able to reschedule if got a dose at least
   def got_reschedule_condition?
-    vaccine = doses.last.vaccine
+    Time.zone.now >= change_reschedule_after
+  end
 
-    if vaccine.name == 'Pfizer'
-      time_for_reschedule = doses.last.appointment.start + vaccine.second_dose_after_in_days.days
+  def change_reschedule_after
+    # This is a transitory change on update of only doses Pfizer at moment
+    if doses.last.vaccine.name == 'Pfizer'
+      doses.last.appointment.start + doses.last.vaccine.second_dose_after_in_days.days
     else
       current_appointment = appointments.not_checked_out.current
 
-      if current_appointment
-        time_for_reschedule = current_appointment.start
+      if current_appointment.present?
+        current_appointment.start
       else
-        time_for_reschedule = doses.last.appointment.start + vaccine.second_dose_after_in_days.days
+        doses.last.appointment.start + vaccine.second_dose_after_in_days.days
       end
     end
-
-    Time.zone.now >= time_for_reschedule
   end
 
   def vaccinated?

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -73,17 +73,21 @@ class Patient < ApplicationRecord
 
   # rubocop:disable Metrics/AbcSize
   def change_reschedule_after
-    # This is a transitory change on update of only doses Pfizer at moment
-    if doses.last.vaccine.name == 'Pfizer'
-      doses.last.appointment.start + doses.last.vaccine.second_dose_after_in_days.days
-    else
-      current_appointment = appointments.not_checked_out.current
-
-      if current_appointment.present?
-        current_appointment.start
+    if doses.count.positive?
+      # This is a transitory change on update of only doses Pfizer at the moment
+      if doses.last.vaccine.name == 'Pfizer'
+        doses.last.appointment.start + doses.last.vaccine.second_dose_after_in_days.days
       else
-        doses.last.appointment.start + vaccine.second_dose_after_in_days.days
+        current_appointment = appointments.not_checked_out.current
+
+        if current_appointment.present?
+          current_appointment.start
+        else
+          doses.last.appointment.start + vaccine.second_dose_after_in_days.days
+        end
       end
+    else
+      Time.zone.now - 1.hour
     end
   end
   # rubocop:enable Metrics/AbcSize

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -71,6 +71,7 @@ class Patient < ApplicationRecord
     Time.zone.now >= change_reschedule_after
   end
 
+  # rubocop:disable Metrics/AbcSize
   def change_reschedule_after
     # This is a transitory change on update of only doses Pfizer at moment
     if doses.last.vaccine.name == 'Pfizer'
@@ -85,6 +86,7 @@ class Patient < ApplicationRecord
       end
     end
   end
+  # rubocop:enable Metrics/AbcSize
 
   def vaccinated?
     # If there are any doses and the last one doesn't have a follow up date, it means user is vaccinated

--- a/app/views/community/appointments/_home_has_appointment.html.erb
+++ b/app/views/community/appointments/_home_has_appointment.html.erb
@@ -52,7 +52,7 @@
             <div class="col">
                 <div class="alert alert-danger" role="danger" data-cy="cannotCancelAndRescheduleText">
                   <h4 class="alert-title">
-                  <%= t("alerts.cannot_reschedule_yet_head", datetime: l(@appointment.can_change_after, format: :human)) %>
+                  <%= t("alerts.cannot_reschedule_yet_head", datetime: l(@can_change_after, format: :human)) %>
                   </h4>
                   <%= t("alerts.cannot_reschedule_yet") %>
                 </div>

--- a/app/views/community/appointments/_home_has_appointment.html.erb
+++ b/app/views/community/appointments/_home_has_appointment.html.erb
@@ -26,7 +26,7 @@
         <%= embedded_page :patient_scheduled -%>
       </li>
       <li class="list-group-item d-print-none">
-        <% if @appointment.can_cancel_and_reschedule? -%>
+        <% if @can_cancel_or_reschedule -%>
           <div class="row">
             <div class="col">
               <%= button_to community_appointment_path(id: @appointment.id), method: :delete,

--- a/db/seeds/development/0_vaccines.rb
+++ b/db/seeds/development/0_vaccines.rb
@@ -2,7 +2,10 @@
   { name: 'CoronaVac', formal_name: 'Sinovac COVID-19 CoronaVac',
     second_dose_after_in_days: 4 * 7 },
   { name: 'AstraZeneca', formal_name: 'Oxford–AstraZeneca COVID-19 ChAdOx1 (AZD1222)',
-    second_dose_after_in_days: 13 * 7 }
+    second_dose_after_in_days: 13 * 7 },
+  { name: 'Pfizer', formal_name: 'Pfizer–BioNTech COVID-19 Comirnaty',
+    second_dose_after_in_days: 8 * 7 },
+  { name: 'Janssen', formal_name: 'Janssen'}
 ].each do |h|
   Vaccine.find_or_initialize_by(name: h[:name]).tap { |r| r.update!(h) }
 end

--- a/spec/factories/ubs_factory.rb
+++ b/spec/factories/ubs_factory.rb
@@ -13,4 +13,20 @@ FactoryBot.define do
     address { 'Rua Principal, 256' }
     active { true }
   end
+
+  factory :ubs_for_reschedule, class: 'Ubs' do
+    name { 'UBS Sul' }
+    neighborhood { create(:neighborhood) }
+    neighborhoods { [] }
+    shift_start { '08:00' }
+    shift_end { '18:00' }
+    break_start { '12:00' }
+    break_end { '13:00' }
+    slot_interval_minutes { 15 }
+    sequence(:cnes) { |n| n }
+    phone { '9999-8888' }
+    address { 'Rua Secundaria, 256' }
+    active { true }
+    enabled_for_reschedule { true }
+  end
 end

--- a/spec/factories/vaccines_factory.rb
+++ b/spec/factories/vaccines_factory.rb
@@ -4,4 +4,10 @@ FactoryBot.define do
     formal_name { 'Vacina Boa' }
     second_dose_after_in_days { 28 }
   end
+
+  factory :pfizer_vaccine, class: 'Vaccine' do
+    name { 'Pfizer' }
+    formal_name { 'Pfizer–BioNTech COVID-19 Comirnaty' }
+    second_dose_after_in_days { 85 }
+  end
 end

--- a/spec/services/appointment_scheduler_spec.rb
+++ b/spec/services/appointment_scheduler_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe AppointmentScheduler, type: :service, use_transactional_tests: fa
     it 'returns no slots result with no changes to appointments' do
       expect do
         expect(
-          scheduler.schedule(patient: patient, ubs_id: nil, from: earliest_allowed)
+          scheduler.schedule(patient: patient, ubs_id: nil, from: earliest_allowed, reschedule: false)
         ).to eq([AppointmentScheduler::NO_SLOTS])
       end.not_to(change { Appointment.order(:id).map(&:attributes) })
     end
@@ -50,7 +50,7 @@ RSpec.describe AppointmentScheduler, type: :service, use_transactional_tests: fa
     it 'returns no slots result with no changes to appointments' do
       expect do
         expect(
-          scheduler.schedule(patient: patient, ubs_id: nil, from: earliest_allowed)
+          scheduler.schedule(patient: patient, ubs_id: nil, from: earliest_allowed, reschedule: false)
         ).to eq([AppointmentScheduler::NO_SLOTS])
       end.not_to(change { Appointment.order(:id).map(&:attributes) })
     end
@@ -64,7 +64,7 @@ RSpec.describe AppointmentScheduler, type: :service, use_transactional_tests: fa
     it 'returns conditions unmet result with no changes to appointments' do
       expect do
         expect(
-          scheduler.schedule(patient: patient, ubs_id: nil, from: earliest_allowed)
+          scheduler.schedule(patient: patient, ubs_id: nil, from: earliest_allowed, reschedule: false)
         ).to eq([described_class::CONDITIONS_UNMET])
       end.not_to(change { Appointment.order(:id).map(&:attributes) })
     end
@@ -81,7 +81,8 @@ RSpec.describe AppointmentScheduler, type: :service, use_transactional_tests: fa
       expect do
         expect(
           scheduler.schedule(patient: patient, ubs_id: nil,
-                             from: past_max_schedule_time_ahead)
+                             from: past_max_schedule_time_ahead,
+                             reschedule: false)
         ).to eq([AppointmentScheduler::NO_SLOTS])
       end.not_to(change { Appointment.order(:id).map(&:attributes) })
     end
@@ -101,7 +102,7 @@ RSpec.describe AppointmentScheduler, type: :service, use_transactional_tests: fa
     it 'updates exactly one appointment' do
       expect do
         expect(
-          scheduler.schedule(patient: patient, ubs_id: nil, from: earliest_allowed)
+          scheduler.schedule(patient: patient, ubs_id: nil, from: earliest_allowed, reschedule: false)
         ).to eq([described_class::SUCCESS, Appointment.find_by(patient_id: patient.id)])
       end.to change { patient.appointments.count }.by(1)
     end


### PR DESCRIPTION
Nova regra de reagendameto apenas para vacina Pfizer (temporariamente), podendo ser feito o reagendamento da D2 após a data de intervalo definido entre a D1 e D2.

Hoje o paciente precisaria aguardar passar a data e hora da D2 agendada automaticamente após aplicação da D1 (cerca de 3 meses até poucos dias atrás) para poder reagendar a D2 novamente.

Regra alterada a pedido da Secretaria da Saúde.
