### PR TITLE
Bloquei botão quando existe dose cadastrada (#371)

### DIFF
--- a/app/helpers/admin/patients_helper.rb
+++ b/app/helpers/admin/patients_helper.rb
@@ -14,5 +14,15 @@ module Admin
         links << search_link(current_search, total_count, admin_patients_path(search: current_search)) if current_search.present?
       end.join.html_safe # rubocop:disable Rails/OutputSafety
     end
+
+    def register_appointment(patient)
+      link_class = 'btn btn-success'
+
+      if patient.doses.any?
+        link_class = 'btn btn-success disabled'
+      end
+
+      link_to "Registrar dose", new_admin_appointment_path(patient_id: patient.id), class: link_class
+    end
   end
 end

--- a/app/views/admin/patients/show.html.erb
+++ b/app/views/admin/patients/show.html.erb
@@ -155,7 +155,7 @@
         </h1>
       </div>
       <div class="col-2">
-        <%= link_to "Registrar dose", new_admin_appointment_path(patient_id: @patient.id), class: 'btn btn-success' %>
+        <%= register_appointment(@patient) %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Bloqueia o botão de registro de nova dosa, caso o usuário já possua uma dose cadastrada

## :computer: SCREENSHOTS

https://imgur.com/a/uwUrrGR
![image](https://user-images.githubusercontent.com/2079263/138204942-5b1595eb-0651-436d-bbf0-498e0b462952.png)


## :squirrel: TESTS

### SCENARIO ONE

1. Acessar o endpoint de paciente 
2. Não será possivel clicar no botão de Registrar dose, caso o paciente já tenha uma dose cadastrada
3. Caso o usuário não tenha dose alguma cadastrada, será possível clicar no botão

Describe what the expected results are.

## :package: DEPLOY

If necessary, this section should be used to describe the deploy process.
